### PR TITLE
table: Render to io.Writer; Render as Markdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ tools:
 #	go install github.com/golang/mock/mockgen
 
 bench:
-	go test github.com/jedib0t/go-pretty/list -bench=. -benchmem
-	go test github.com/jedib0t/go-pretty/table -bench=. -benchmem
+	go test -bench=. -benchmem
 
 build:
 	go run demo/demo.go

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ A demonstration of all the capabilities can be found here: [list/demo/demo.go](l
 
 Partial output of `make bench`:
 ```
-BenchmarkList_Render-8           1000000              1645 ns/op             608 B/op         24 allocs/op
-BenchmarkTable_Render-8            50000             24826 ns/op            6995 B/op        410 allocs/op
-BenchmarkTable_RenderCSV-8        300000              5425 ns/op            2657 B/op         90 allocs/op
-BenchmarkTable_RenderHTML-8       200000              7080 ns/op            4129 B/op         89 allocs/op
+BenchmarkList_Render-8                   1000000              1651 ns/op             608 B/op         24 allocs/op
+BenchmarkTable_Render-8                    50000             26410 ns/op            7138 B/op        416 allocs/op
+BenchmarkTable_RenderCSV-8                300000              5827 ns/op            2656 B/op         90 allocs/op
+BenchmarkTable_RenderHTML-8               200000              7435 ns/op            4129 B/op         89 allocs/op
+BenchmarkTable_RenderMarkdown-8           200000              7493 ns/op            4129 B/op         89 allocs/op
 ```

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,70 @@
+package gopretty
+
+import (
+	"testing"
+
+	"github.com/jedib0t/go-pretty/table"
+	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/list"
+)
+
+var (
+	listItem1      = "Game Of Thrones"
+	listItems2     = []interface{}{"Winter", "Is", "Coming"}
+	listItems3     = []interface{}{"This", "Is", "Known"}
+	tableRowAlign  = []text.Align{text.AlignDefault, text.AlignLeft, text.AlignLeft, text.AlignRight}
+	tableCaption   = "table-caption"
+	tableRowFooter = table.Row{"", "", "Total", 10000}
+	tableRowHeader = table.Row{"#", "First Name", "Last Name", "Salary"}
+	tableRows      = []table.Row{
+		{1, "Arya", "Stark", 3000},
+		{20, "Jon", "Snow", 2000, "You know nothing, Jon Snow!"},
+		{300, "Tyrion", "Lannister", 5000},
+	}
+)
+
+func generateBenchmarkTable() table.Writer {
+	tw := table.NewWriter()
+	tw.AppendHeader(tableRowHeader)
+	tw.AppendRows(tableRows)
+	tw.AppendFooter(tableRowFooter)
+	tw.SetAlign(tableRowAlign)
+	tw.SetCaption(tableCaption)
+	return tw
+}
+
+func BenchmarkList_Render(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		lw := list.NewWriter()
+		lw.AppendItem(listItem1)
+		lw.Indent()
+		lw.AppendItems(listItems2)
+		lw.Indent()
+		lw.AppendItems(listItems3)
+		lw.Render()
+	}
+}
+
+func BenchmarkTable_Render(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		generateBenchmarkTable().Render()
+	}
+}
+
+func BenchmarkTable_RenderCSV(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		generateBenchmarkTable().RenderCSV()
+	}
+}
+
+func BenchmarkTable_RenderHTML(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		generateBenchmarkTable().RenderHTML()
+	}
+}
+
+func BenchmarkTable_RenderMarkdown(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		generateBenchmarkTable().RenderHTML()
+	}
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -7,22 +7,10 @@ import (
 )
 
 var (
-	listItem1  = "Game Of Thrones"
-	listItems2 = []interface{}{"Winter", "Is", "Coming"}
-	listItems3 = []interface{}{"This", "Is", "Known"}
+	testItem1  = "Game Of Thrones"
+	testItems2 = []interface{}{"Winter", "Is", "Coming"}
+	testItems3 = []interface{}{"This", "Is", "Known"}
 )
-
-func BenchmarkList_Render(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		lw := NewWriter()
-		lw.AppendItem(listItem1)
-		lw.Indent()
-		lw.AppendItems(listItems2)
-		lw.Indent()
-		lw.AppendItems(listItems3)
-		lw.Render()
-	}
-}
 
 func TestNewWriter(t *testing.T) {
 	lw := NewWriter()
@@ -37,8 +25,8 @@ func TestList_AppendItem(t *testing.T) {
 	list := List{}
 	assert.Equal(t, 0, list.Length())
 
-	list.AppendItem(listItem1)
-	list.AppendItem(listItem1)
+	list.AppendItem(testItem1)
+	list.AppendItem(testItem1)
 	assert.Equal(t, 2, list.Length())
 }
 
@@ -46,8 +34,8 @@ func TestList_AppendItems(t *testing.T) {
 	list := List{}
 	assert.Equal(t, 0, list.Length())
 
-	list.AppendItems(listItems2)
-	assert.Equal(t, len(listItems2), list.Length())
+	list.AppendItems(testItems2)
+	assert.Equal(t, len(testItems2), list.Length())
 }
 
 func TestList_Indent(t *testing.T) {
@@ -63,11 +51,11 @@ func TestList_Indent(t *testing.T) {
 
 func TestList_Render(t *testing.T) {
 	lw := NewWriter()
-	lw.AppendItem(listItem1)
+	lw.AppendItem(testItem1)
 	lw.Indent()
-	lw.AppendItems(listItems2)
+	lw.AppendItems(testItems2)
 	lw.Indent()
-	lw.AppendItems(listItems3)
+	lw.AppendItems(testItems3)
 	lw.SetStyle(styleTest)
 
 	expectedOut := `^> Game Of Thrones
@@ -83,11 +71,11 @@ c<f> Winter
 
 func TestList_RenderWithoutStyle(t *testing.T) {
 	lw := NewWriter()
-	lw.AppendItem(listItem1)
+	lw.AppendItem(testItem1)
 	lw.Indent()
-	lw.AppendItems(listItems2)
+	lw.AppendItems(testItems2)
 	lw.Indent()
-	lw.AppendItems(listItems3)
+	lw.AppendItems(testItems3)
 
 	expectedOut := `- Game Of Thrones
 --- Winter

--- a/table/README.md
+++ b/table/README.md
@@ -2,8 +2,9 @@
 
 Pretty-print tables into ASCII/Unicode strings.
 
-  - Supports Header and Footer
-  - Supports Adding Rows one-by-one or as a group
+  - Add Rows one-by-one or as a group
+  - Add Header(s) and Footer(s)
+  - Set output to be mirrored to an io.Writer object like os.StdOut
   - Auto (horizontal) Align (numeric columns are aligned Right)
   - Custom (horizontal) Align per column
   - Custom (vertical) VAlign per column (and multi-line column support)
@@ -17,6 +18,7 @@ Pretty-print tables into ASCII/Unicode strings.
     - (ASCII/Unicode) Table
     - CSV
     - HTML Table (with custom CSS Style)
+    - Markdown Table
 
 
 ```
@@ -38,8 +40,6 @@ Documentation: [GoDoc](https://godoc.org/github.com/jedib0t/go-pretty/table)
 ### TODO
 
   - Performance Optimizations (Memory Usage)
-  - Render to io.Writer (and not return a string)
-  - Render as Markdown
   - Spreadsheet Format (Row Headers like [A, B, C, ...] and Column Indices)
   - Row and Cell Width Restrictions
   - Generic Cell Content Transformers (with some ready-made ones)

--- a/table/table.go
+++ b/table/table.go
@@ -2,6 +2,7 @@ package table
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"unicode/utf8"
 
@@ -46,6 +47,8 @@ type Table struct {
 	maxRowLength int
 	// numColumns stores the (max.) number of columns seen
 	numColumns int
+	// outputMirror stores an io.Writer where the "Render" functions would write
+	outputMirror io.Writer
 	// rows stores the rows that make up the body
 	rows []Row
 	// rowsFooter stores the rows that make up the footer
@@ -121,7 +124,7 @@ func (t *Table) Render() string {
 		out.WriteRune('\n')
 		out.WriteString(t.caption)
 	}
-	return out.String()
+	return t.render(&out)
 }
 
 // RenderCSV renders the Table in a CSV format. Example:
@@ -137,7 +140,7 @@ func (t *Table) RenderCSV() string {
 	t.renderRowsCSV(&out, t.rowsHeader)
 	t.renderRowsCSV(&out, t.rows)
 	t.renderRowsCSV(&out, t.rowsFooter)
-	return out.String()
+	return t.render(&out)
 }
 
 // RenderHTML renders the Table in a HTML format. Example:
@@ -195,7 +198,7 @@ func (t *Table) RenderHTML() string {
 	t.renderRowsHTML(&out, t.rows, false, false)
 	t.renderRowsHTML(&out, t.rowsFooter, false, true)
 	out.WriteString("</table>")
-	return out.String()
+	return t.render(&out)
 }
 
 // SetAlign sets the horizontal-align for each column in all the rows.
@@ -237,6 +240,12 @@ func (t *Table) SetColorsHeader(textColors []text.Colors) {
 // when rendering the Table in HTML format.
 func (t *Table) SetHTMLCSSClass(cssClass string) {
 	t.htmlCSSClass = cssClass
+}
+
+// SetOutputMirror sets an io.Writer for all the Render functions to "Write" to
+// in addition to returning a string.
+func (t *Table) SetOutputMirror(mirror io.Writer) {
+	t.outputMirror = mirror
 }
 
 // SetStyle overrides the DefaultStyle with the provided one.
@@ -352,6 +361,14 @@ func (t *Table) init() {
 		t.maxRowLength += utf8.RuneCountInString(horizontalSeparatorCol)
 		t.rowSeparator[colIdx] = horizontalSeparatorCol
 	}
+}
+
+func (t *Table) render(out *strings.Builder) string {
+	outStr := out.String()
+	if t.outputMirror != nil {
+		t.outputMirror.Write([]byte(outStr))
+	}
+	return outStr
 }
 
 func (t *Table) renderColumn(out *strings.Builder, row Row, colIdx int, maxColumnLength int, colors []*color.Color, isFirstRow bool, isLastRow bool, isSeparatorRow bool, format text.Format) {
@@ -486,24 +503,26 @@ func (t *Table) renderRowsCSV(out *strings.Builder, rows []Row) {
 }
 
 func (t *Table) renderRowsHTML(out *strings.Builder, rows []Row, isHeader bool, isFooter bool) {
-	// determine that tag to use based on the type of the row
-	rowsTag := "tbody"
-	if isHeader {
-		rowsTag = "thead"
-	} else if isFooter {
-		rowsTag = "tfoot"
-	}
+	if len(rows) > 0 {
+		// determine that tag to use based on the type of the row
+		rowsTag := "tbody"
+		if isHeader {
+			rowsTag = "thead"
+		} else if isFooter {
+			rowsTag = "tfoot"
+		}
 
-	// render all the rows enclosed by the "rowsTag"
-	out.WriteString("  <")
-	out.WriteString(rowsTag)
-	out.WriteString(">\n")
-	for _, row := range rows {
-		t.renderRowHTML(out, row, isHeader, isFooter)
+		// render all the rows enclosed by the "rowsTag"
+		out.WriteString("  <")
+		out.WriteString(rowsTag)
+		out.WriteString(">\n")
+		for _, row := range rows {
+			t.renderRowHTML(out, row, isHeader, isFooter)
+		}
+		out.WriteString("  </")
+		out.WriteString(rowsTag)
+		out.WriteString(">\n")
 	}
-	out.WriteString("  </")
-	out.WriteString(rowsTag)
-	out.WriteString(">\n")
 }
 
 func (t *Table) renderRowCSV(out *strings.Builder, row Row) {

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -27,54 +27,20 @@ var (
 		{300, "Tyrion", "Lannister", 5000},
 	}
 	testRowMultiLine = Row{0, "Winter", "Is", 0, "Coming.\nThe North Remembers!"}
-	testRowTabs      = Row{0, "Valar", "Morghulis", 0, "\t"}
+	testRowNewLines  = Row{0, "Valar", "Morghulis", 0, "Faceless\nMen"}
+	testRowPipes     = Row{0, "Valar", "Morghulis", 0, "Faceless|Men"}
+	testRowTabs      = Row{0, "Valar", "Morghulis", 0, "Faceless\tMen"}
 	testColors1      = text.Colors{color.FgWhite, color.BgBlack}
 	testColors2      = text.Colors{color.FgBlack, color.BgWhite}
 )
 
-type myMockOutputMirror struct{
+type myMockOutputMirror struct {
 	mirroredOutput string
 }
 
 func (t *myMockOutputMirror) Write(p []byte) (n int, err error) {
 	t.mirroredOutput = string(p)
 	return len(p), nil
-}
-
-func BenchmarkTable_Render(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		tw := NewWriter()
-		tw.AppendHeader(testHeader)
-		tw.AppendRows(testRows)
-		tw.AppendFooter(testFooter)
-		tw.SetAlign(testAlign)
-		tw.SetCaption(testCaption)
-		tw.Render()
-	}
-}
-
-func BenchmarkTable_RenderCSV(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		tw := NewWriter()
-		tw.AppendHeader(testHeader)
-		tw.AppendRows(testRows)
-		tw.AppendFooter(testFooter)
-		tw.SetAlign(testAlign)
-		tw.SetCaption(testCaption)
-		tw.RenderCSV()
-	}
-}
-
-func BenchmarkTable_RenderHTML(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		tw := NewWriter()
-		tw.AppendHeader(testHeader)
-		tw.AppendRows(testRows)
-		tw.AppendFooter(testFooter)
-		tw.SetAlign(testAlign)
-		tw.SetCaption(testCaption)
-		tw.RenderHTML()
-	}
 }
 
 func TestNewWriter(t *testing.T) {
@@ -217,7 +183,7 @@ func TestTable_RenderCSV(t *testing.T) {
 300,Tyrion,Lannister,5000,
 0,Winter,Is,0,"Coming.
 The North Remembers!"
-0,Valar,Morghulis,0,    
+0,Valar,Morghulis,0,Faceless    Men
 ,,Total,10000,`
 
 	assert.Equal(t, expectedOut, tw.RenderCSV())
@@ -284,6 +250,28 @@ func TestTable_RenderHTML(t *testing.T) {
 </table>`
 
 	assert.Equal(t, expectedOut, tw.RenderHTML())
+}
+
+func TestTable_RenderMarkdown(t *testing.T) {
+	tw := NewWriter()
+	tw.AppendHeader(testHeader)
+	tw.AppendRows(testRows)
+	tw.AppendRow(testRowNewLines)
+	tw.AppendRow(testRowPipes)
+	tw.AppendFooter(testFooter)
+	tw.SetCaption(testCaption)
+
+	expectedOut := `| # | First Name | Last Name | Salary |  |
+| ---:| --- | --- | ---:| --- |
+| 1 | Arya | Stark | 3000 |  |
+| 20 | Jon | Snow | 2000 | You know nothing, Jon Snow! |
+| 300 | Tyrion | Lannister | 5000 |  |
+| 0 | Valar | Morghulis | 0 | Faceless<br>Men |
+| 0 | Valar | Morghulis | 0 | Faceless\|Men |
+|  |  | Total | 10000 |  |
+_test-caption_`
+
+	assert.Equal(t, expectedOut, tw.RenderMarkdown())
 }
 
 func TestTable_SetAlign(t *testing.T) {

--- a/table/writer.go
+++ b/table/writer.go
@@ -1,6 +1,10 @@
 package table
 
-import "github.com/jedib0t/go-pretty/text"
+import (
+	"io"
+
+	"github.com/jedib0t/go-pretty/text"
+)
 
 // Writer declares the interfaces implemented by Table.
 type Writer interface {
@@ -18,6 +22,7 @@ type Writer interface {
 	SetColorsFooter(colors []text.Colors)
 	SetColorsHeader(colors []text.Colors)
 	SetHTMLCSSClass(cssClass string)
+	SetOutputMirror(mirror io.Writer)
 	SetStyle(style Style)
 	SetVAlign(vAlign []text.VAlign)
 	ShowBorder(show bool)

--- a/table/writer.go
+++ b/table/writer.go
@@ -16,6 +16,7 @@ type Writer interface {
 	Render() string
 	RenderCSV() string
 	RenderHTML() string
+	RenderMarkdown() string
 	SetAlign(align []text.Align)
 	SetCaption(format string, a ...interface{})
 	SetColors(colors []text.Colors)

--- a/text/align.go
+++ b/text/align.go
@@ -69,6 +69,20 @@ func (a Align) HTMLProperty() string {
 	}
 }
 
+// MarkdownProperty returns the equivalent Markdown horizontal-align separator.
+func (a Align) MarkdownProperty() string {
+	switch a {
+	case AlignLeft:
+		return ":--- "
+	case AlignCenter:
+		return ":---:"
+	case AlignRight:
+		return " ---:"
+	default:
+		return " --- "
+	}
+}
+
 func (a Align) justifyText(text string, textLength int, maxLength int) string {
 	// split the text into individual words
 	wordsUnfiltered := strings.Split(text, " ")

--- a/text/align_test.go
+++ b/text/align_test.go
@@ -35,3 +35,16 @@ func TestAlign_HTMLProperty(t *testing.T) {
 		assert.Contains(t, align.HTMLProperty(), htmlStyle)
 	}
 }
+
+func TestAlign_MarkdownProperty(t *testing.T) {
+	aligns := map[Align]string{
+		AlignDefault: " --- ",
+		AlignLeft:    ":--- ",
+		AlignCenter:  ":---:",
+		AlignJustify: " --- ",
+		AlignRight:   " ---:",
+	}
+	for align, markdownSeparator := range aligns {
+		assert.Contains(t, align.MarkdownProperty(), markdownSeparator)
+	}
+}


### PR DESCRIPTION
## Proposed Changes
  - Mirror the rendering output to an io.Writer in addition to returning a string
  - RenderMarkdown() to generate a Markdown-style table
  - Move benchmarks to bench_test.go