### PR TITLE
goveralls: fix coverage for multi-package project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea/
 /demo*
 /profile/
+.coverprofile

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ before_script:
 
 # CI Pipeline.
 script:
-  - $GOPATH/bin/goveralls -service=travis-ci
-  - make lint vet cyclo bench
+  - make test bench
+  - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=.coverprofile

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ profile:
 	sh profile.sh
 
 test: lint vet cyclo
-	go test -cover $(shell go list ./...)
+	go test -cover -coverprofile=.coverprofile $(shell go list ./...)
 
 vet:
 	go vet $(shell go list ./...)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # go-pretty
 
 [![Build Status](https://travis-ci.org/jedib0t/go-pretty.svg?branch=master)](https://travis-ci.org/jedib0t/go-pretty)
+[![Coverage Status](https://coveralls.io/repos/github/jedib0t/go-pretty/badge.svg?branch=master)](https://coveralls.io/github/jedib0t/go-pretty?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jedib0t/go-pretty)](https://goreportcard.com/report/github.com/jedib0t/go-pretty)
 [![GoDoc](https://godoc.org/github.com/jedib0t/go-pretty?status.svg)](https://godoc.org/github.com/jedib0t/go-pretty)
 
-<!-- [![Coverage Status](https://coveralls.io/repos/github/jedib0t/go-pretty/badge.svg?branch=master)](https://coveralls.io/github/jedib0t/go-pretty?branch=master) -->
 
 Utilities to prettify console output of tables, lists, text, etc.
 


### PR DESCRIPTION
## Proposed Changes
  - projects with multiple packages don't play well with `go test -cover` and goveralls
  - solve this by using the `go1.10` feature of dumping coverage to a local file
    - and make goveralls use the pre-generated coverfile instead of running tests by itself