### PR TITLE
table: auto-indexed columns should not repeat index in all lines of row

### DIFF
--- a/table/render.go
+++ b/table/render.go
@@ -79,14 +79,14 @@ func (t *Table) renderColumnAutoIndex(out *strings.Builder, rowNum int, hint ren
 	var outAutoIndex strings.Builder
 	outAutoIndex.Grow(t.maxColumnLengths[0])
 
-	if rowNum < 0 {
+	if hint.isSeparatorRow {
 		numChars := t.autoIndexVIndexMaxLength + utf8.RuneCountInString(t.style.Box.PaddingLeft) +
 			utf8.RuneCountInString(t.style.Box.PaddingRight)
 		outAutoIndex.WriteString(util.RepeatAndTrim(t.style.Box.MiddleHorizontal, numChars))
 	} else {
 		outAutoIndex.WriteString(t.style.Box.PaddingLeft)
 		rowNumStr := fmt.Sprint(rowNum)
-		if hint.isHeaderRow || hint.isFooterRow {
+		if hint.isHeaderRow || hint.isFooterRow || hint.rowLineNumber > 1 {
 			rowNumStr = strings.Repeat(" ", t.autoIndexVIndexMaxLength)
 		}
 		outAutoIndex.WriteString(text.AlignRight.Apply(rowNumStr, t.autoIndexVIndexMaxLength))
@@ -254,6 +254,7 @@ func (t *Table) renderRow(out *strings.Builder, rowNum int, row rowStr, hint ren
 					rowLine[colIdx] = colLines[colLineIdx]
 				}
 				hint.isLastLineOfRow = bool(colLineIdx == colMaxLines-1)
+				hint.rowLineNumber = colLineIdx + 1
 				t.renderLine(out, rowNum, rowLine, hint)
 			}
 		}

--- a/table/table.go
+++ b/table/table.go
@@ -418,6 +418,7 @@ type renderHint struct {
 	isLastLineOfRow   bool // last-line of the current row?
 	isLastRow         bool // last-row of header/footer/regular-rows?
 	isSeparatorRow    bool // separator row?
+	rowLineNumber     int  // the line number for a multi-line row
 }
 
 func (h *renderHint) isRegularRow() bool {

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -264,6 +264,19 @@ func TestTable_SetAutoIndex(t *testing.T) {
 \---v-----v------------v-----------v--------v-----------------------------/`
 	assert.True(t, table.autoIndex)
 	assert.Equal(t, expectedOut, table.Render())
+
+	table.AppendRow(testRowMultiLine)
+	expectedOut = `(---^-----^------------^-----------^--------^-----------------------------)
+[< >|<  #>|<FIRST NAME>|<LAST NAME>|<SALARY>|<                           >]
+{---+-----+------------+-----------+--------+-----------------------------}
+[<1>|<  1>|<Arya      >|<Stark    >|<  3000>|<                           >]
+[<2>|< 20>|<Jon       >|<Snow     >|<  2000>|<You know nothing, Jon Snow!>]
+[<3>|<300>|<Tyrion    >|<Lannister>|<  5000>|<                           >]
+[<4>|<  0>|<Winter    >|<Is       >|<     0>|<Coming.                    >]
+[< >|<   >|<          >|<         >|<      >|<The North Remembers!       >]
+[< >|<   >|<          >|<         >|<      >|<This is known.             >]
+\---v-----v------------v-----------v--------v-----------------------------/`
+	assert.Equal(t, expectedOut, table.Render())
 }
 
 func TestTable_SetCaption(t *testing.T) {


### PR DESCRIPTION
## Proposed Changes
When auto-indexing is turned on, and the table has a multi-line row, each line of the multi-line row gets the index value printed. This fix will ensure that only the first line in a multi-line row has the index value.