### PR TITLE
table: allowed column length should behave like "max" column length

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -367,14 +367,9 @@ func (t *Table) initForRenderMaxColumnLength() {
 	var findMaxColumnLengths = func(rows []rowStr) {
 		for _, row := range rows {
 			for colIdx, colStr := range row {
-				allowedColumnLength := t.getAllowedColumnLength(colIdx)
-				if allowedColumnLength > 0 {
-					t.maxColumnLengths[colIdx] = allowedColumnLength
-				} else {
-					colLongestLineLength := util.GetLongestLineLength(colStr)
-					if colLongestLineLength > t.maxColumnLengths[colIdx] {
-						t.maxColumnLengths[colIdx] = colLongestLineLength
-					}
+				longestLineLen := util.GetLongestLineLength(colStr)
+				if longestLineLen > t.maxColumnLengths[colIdx] {
+					t.maxColumnLengths[colIdx] = longestLineLen
 				}
 			}
 		}
@@ -384,6 +379,14 @@ func (t *Table) initForRenderMaxColumnLength() {
 	findMaxColumnLengths(t.rowsHeader)
 	findMaxColumnLengths(t.rows)
 	findMaxColumnLengths(t.rowsFooter)
+
+	// restrict the column lengths if any are overthe allowed lengths
+	for colIdx := range t.maxColumnLengths {
+		allowedLen := t.getAllowedColumnLength(colIdx)
+		if allowedLen > 0 && t.maxColumnLengths[colIdx] > allowedLen {
+			t.maxColumnLengths[colIdx] = allowedLen
+		}
+	}
 }
 
 func (t *Table) initForRenderRowSeparator() {

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -188,6 +188,18 @@ func TestTable_SetAllowedColumnLengths(t *testing.T) {
 \-----v---v----v-----v---------/`
 	assert.Equal(t, []int{0, 1, 2, 3, 7}, table.allowedColumnLengths)
 	assert.Equal(t, expectedOut, table.Render())
+
+	table.SetAllowedColumnLengths([]int{100, 100, 100, 100, 7})
+	expectedOut = `(-----^--------^-----------^------^---------)
+[<  1>|<Arya  >|<Stark    >|<3000>|<       >]
+[< 20>|<Jon   >|<Snow     >|<2000>|<You kno>]
+[<   >|<      >|<         >|<    >|<w nothi>]
+[<   >|<      >|<         >|<    >|<ng, Jon>]
+[<   >|<      >|<         >|<    >|< Snow! >]
+[<300>|<Tyrion>|<Lannister>|<5000>|<       >]
+\-----v--------v-----------v------v---------/`
+	assert.Equal(t, []int{100, 100, 100, 100, 7}, table.allowedColumnLengths)
+	assert.Equal(t, expectedOut, table.Render())
 }
 
 func TestTable_SetAllowedRowLength(t *testing.T) {


### PR DESCRIPTION
## Proposed Changes
  - table: allowed column length should behave like "max" column length; not "min" and "max"