### PR TITLE
minor fixes to progress and text

### DIFF
--- a/progress/tracker.go
+++ b/progress/tracker.go
@@ -32,7 +32,7 @@ func (t *Tracker) ETA() time.Duration {
 	}
 
 	timeTaken := time.Since(t.timeStart)
-	eta := time.Duration((int64(timeTaken) / int64(percDone)) * 100)
+	eta := time.Duration((int64(timeTaken) / int64(percDone)) * int64(100-percDone))
 	return eta
 }
 

--- a/progress/tracker_test.go
+++ b/progress/tracker_test.go
@@ -13,10 +13,10 @@ func TestTracker_ETA(t *testing.T) {
 
 	tracker.timeStart = time.Now()
 	time.Sleep(time.Millisecond * 100)
-	tracker.value = 10
+	tracker.value = 50
 	eta := tracker.ETA()
 	assert.NotEqual(t, time.Duration(0), eta)
-	assert.True(t, eta > time.Second)
+	assert.True(t, eta < time.Second)
 }
 
 func TestTracker_Increment(t *testing.T) {


### PR DESCRIPTION
## Proposed Changes
  - progress: ETA should not be the total progress time
  - text: color: use sync.Map to avoid race condition accessing EscapeSequence map