### PR TITLE
handle \r and \t in list, progress and table

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -100,9 +100,16 @@ func (l *List) Style() *Style {
 }
 
 func (l *List) analyzeAndStringify(item interface{}) *listItem {
+	itemStr := fmt.Sprint(item)
+	if strings.Contains(itemStr, "\t") {
+		itemStr = strings.Replace(itemStr, "\t", "    ", -1)
+	}
+	if strings.Contains(itemStr, "\r") {
+		itemStr = strings.Replace(itemStr, "\r", "", -1)
+	}
 	return &listItem{
 		Level: l.level,
-		Text:  fmt.Sprint(item),
+		Text:  itemStr,
 	}
 }
 

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -9,13 +9,13 @@ import (
 var (
 	testCSSClass = "test-css-class"
 	testItem1    = "Game Of Thrones"
-	testItem1ML  = testItem1 + "\n// George. R. R. Martin"
+	testItem1ML  = testItem1 + "\n\t// George. R. R. Martin"
 	testItems2   = []interface{}{"Winter", "Is", "Coming"}
-	testItems2ML = []interface{}{"Winter\nIs\nComing", "Is", "Coming"}
+	testItems2ML = []interface{}{"Winter\r\nIs\nComing", "Is", "Coming"}
 	testItems3   = []interface{}{"This", "Is", "Known"}
 	testItems3ML = []interface{}{"This\nIs\nKnown", "Is", "Known"}
 	testItem4    = "The Dark Tower"
-	testItem4ML  = testItem4 + "\n// Stephen King"
+	testItem4ML  = testItem4 + "\n\t// Stephen King"
 	testItem5    = "The Gunslinger"
 )
 

--- a/list/render_test.go
+++ b/list/render_test.go
@@ -178,7 +178,7 @@ func TestList_Render_MultiLine(t *testing.T) {
 	lw.AppendItem(testItem5)
 
 	expectedOut := `* Game Of Thrones
-  // George. R. R. Martin
+      // George. R. R. Martin
   * Winter
     Is
     Coming
@@ -190,12 +190,12 @@ func TestList_Render_MultiLine(t *testing.T) {
     * Is
     * Known
 * The Dark Tower
-  // Stephen King
+      // Stephen King
   * The Gunslinger`
 	assert.Equal(t, expectedOut, lw.Render())
 
 	expectedOutRounded := `╭─ Game Of Thrones
-│  // George. R. R. Martin
+│      // George. R. R. Martin
 │  ├─ Winter
 │  │  Is
 │  │  Coming
@@ -207,13 +207,13 @@ func TestList_Render_MultiLine(t *testing.T) {
 │     ├─ Is
 │     ╰─ Known
 ╰─ The Dark Tower
-   // Stephen King
+       // Stephen King
    ╰─ The Gunslinger`
 	lw.SetStyle(StyleConnectedRounded)
 	assert.Equal(t, expectedOutRounded, lw.Render())
 
 	expectedOutHTML := `<ul class="go-pretty-table">
-  <li>Game Of Thrones<br/>// George. R. R. Martin</li>
+  <li>Game Of Thrones<br/>    // George. R. R. Martin</li>
   <ul class="go-pretty-table-1">
     <li>Winter<br/>Is<br/>Coming</li>
     <li>Is</li>
@@ -224,21 +224,21 @@ func TestList_Render_MultiLine(t *testing.T) {
       <li>Known</li>
     </ul>
   </ul>
-  <li>The Dark Tower<br/>// Stephen King</li>
+  <li>The Dark Tower<br/>    // Stephen King</li>
   <ul class="go-pretty-table-1">
     <li>The Gunslinger</li>
   </ul>
 </ul>`
 	assert.Equal(t, expectedOutHTML, lw.RenderHTML())
 
-	expectedOutMarkdown := `  * Game Of Thrones<br/>// George. R. R. Martin
+	expectedOutMarkdown := `  * Game Of Thrones<br/>    // George. R. R. Martin
     * Winter<br/>Is<br/>Coming
     * Is
     * Coming
       * This<br/>Is<br/>Known
       * Is
       * Known
-  * The Dark Tower<br/>// Stephen King
+  * The Dark Tower<br/>    // Stephen King
     * The Gunslinger`
 	assert.Equal(t, expectedOutMarkdown, lw.RenderMarkdown())
 }

--- a/progress/render.go
+++ b/progress/render.go
@@ -148,6 +148,12 @@ func (p *Progress) renderTracker(out *strings.Builder, t *Tracker, hint renderHi
 	if hint.isOverallTracker && !p.showOverallTracker {
 		return
 	}
+	if strings.Contains(t.Message, "\t") {
+		t.Message = strings.Replace(t.Message, "\t", "    ", -1)
+	}
+	if strings.Contains(t.Message, "\r") {
+		t.Message = strings.Replace(t.Message, "\r", "", -1)
+	}
 
 	out.WriteString(text.EraseLine.Sprint())
 	if hint.isOverallTracker {

--- a/progress/render_test.go
+++ b/progress/render_test.go
@@ -218,8 +218,8 @@ func TestProgress_RenderSomeTrackers_OnLeftSide(t *testing.T) {
 	pw := generateWriter()
 	pw.SetOutputWriter(&renderOutput)
 	pw.SetTrackerPosition(PositionLeft)
-	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1", Total: 1000, Units: UnitsDefault})
-	go trackSomething(pw, &Tracker{Message: "Downloading File    # 2", Total: 1000, Units: UnitsBytes})
+	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1\r", Total: 1000, Units: UnitsDefault})
+	go trackSomething(pw, &Tracker{Message: "Downloading File\t# 2", Total: 1000, Units: UnitsBytes})
 	go trackSomething(pw, &Tracker{Message: "Transferring Amount # 3", Total: 1000, Units: UnitsCurrencyDollar})
 	renderAndWait(pw, false)
 
@@ -245,8 +245,8 @@ func TestProgress_RenderSomeTrackers_OnRightSide(t *testing.T) {
 	pw := generateWriter()
 	pw.SetOutputWriter(&renderOutput)
 	pw.SetTrackerPosition(PositionRight)
-	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1", Total: 1000, Units: UnitsDefault})
-	go trackSomething(pw, &Tracker{Message: "Downloading File    # 2", Total: 1000, Units: UnitsBytes})
+	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1\r", Total: 1000, Units: UnitsDefault})
+	go trackSomething(pw, &Tracker{Message: "Downloading File\t# 2", Total: 1000, Units: UnitsBytes})
 	go trackSomething(pw, &Tracker{Message: "Transferring Amount # 3", Total: 1000, Units: UnitsCurrencyDollar})
 	renderAndWait(pw, false)
 
@@ -273,8 +273,8 @@ func TestProgress_RenderSomeTrackers_WithAutoStop(t *testing.T) {
 	pw.SetAutoStop(true)
 	pw.SetOutputWriter(&renderOutput)
 	pw.SetTrackerPosition(PositionRight)
-	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1", Total: 1000, Units: UnitsDefault})
-	go trackSomething(pw, &Tracker{Message: "Downloading File    # 2", Total: 1000, Units: UnitsBytes})
+	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1\r", Total: 1000, Units: UnitsDefault})
+	go trackSomething(pw, &Tracker{Message: "Downloading File\t# 2", Total: 1000, Units: UnitsBytes})
 	go trackSomething(pw, &Tracker{Message: "Transferring Amount # 3", Total: 1000, Units: UnitsCurrencyDollar})
 	renderAndWait(pw, true)
 
@@ -301,8 +301,8 @@ func TestProgress_RenderSomeTrackers_WithLineWidth1(t *testing.T) {
 	pw.SetMessageWidth(5)
 	pw.SetOutputWriter(&renderOutput)
 	pw.SetTrackerPosition(PositionRight)
-	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1", Total: 1000, Units: UnitsDefault})
-	go trackSomething(pw, &Tracker{Message: "Downloading File    # 2", Total: 1000, Units: UnitsBytes})
+	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1\r", Total: 1000, Units: UnitsDefault})
+	go trackSomething(pw, &Tracker{Message: "Downloading File\t# 2", Total: 1000, Units: UnitsBytes})
 	go trackSomething(pw, &Tracker{Message: "Transferring Amount # 3", Total: 1000, Units: UnitsCurrencyDollar})
 	renderAndWait(pw, false)
 
@@ -329,8 +329,8 @@ func TestProgress_RenderSomeTrackers_WithLineWidth2(t *testing.T) {
 	pw.SetMessageWidth(50)
 	pw.SetOutputWriter(&renderOutput)
 	pw.SetTrackerPosition(PositionRight)
-	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1", Total: 1000, Units: UnitsDefault})
-	go trackSomething(pw, &Tracker{Message: "Downloading File    # 2", Total: 1000, Units: UnitsBytes})
+	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1\r", Total: 1000, Units: UnitsDefault})
+	go trackSomething(pw, &Tracker{Message: "Downloading File\t# 2", Total: 1000, Units: UnitsBytes})
 	go trackSomething(pw, &Tracker{Message: "Transferring Amount # 3", Total: 1000, Units: UnitsCurrencyDollar})
 	renderAndWait(pw, false)
 
@@ -358,8 +358,8 @@ func TestProgress_RenderSomeTrackers_WithOverallTracker(t *testing.T) {
 	pw.SetTrackerPosition(PositionRight)
 	pw.ShowOverallTracker(true)
 	pw.Style().Options.TimeOverallPrecision = time.Millisecond
-	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1", Total: 1000, Units: UnitsDefault})
-	go trackSomething(pw, &Tracker{Message: "Downloading File    # 2", Total: 1000, Units: UnitsBytes})
+	go trackSomething(pw, &Tracker{Message: "Calculation Total   # 1\r", Total: 1000, Units: UnitsDefault})
+	go trackSomething(pw, &Tracker{Message: "Downloading File\t# 2", Total: 1000, Units: UnitsBytes})
 	go trackSomething(pw, &Tracker{Message: "Transferring Amount # 3", Total: 1000, Units: UnitsCurrencyDollar})
 	renderAndWait(pw, false)
 

--- a/table/table.go
+++ b/table/table.go
@@ -260,6 +260,9 @@ func (t *Table) analyzeAndStringify(row Row, isHeader bool, isFooter bool) rowSt
 		if strings.Contains(colStr, "\t") {
 			colStr = strings.Replace(colStr, "\t", "    ", -1)
 		}
+		if strings.Contains(colStr, "\r") {
+			colStr = strings.Replace(colStr, "\r", "", -1)
+		}
 		rowOut[colIdx] = colStr
 	}
 	return rowOut

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -28,7 +28,7 @@ var (
 		{20, "Jon", "Snow", 2000, "You know nothing, Jon Snow!"},
 		{300, "Tyrion", "Lannister", 5000},
 	}
-	testRowMultiLine = Row{0, "Winter", "Is", 0, "Coming.\nThe North Remembers!\nThis is known."}
+	testRowMultiLine = Row{0, "Winter", "Is", 0, "Coming.\r\nThe North Remembers!\nThis is known."}
 	testRowNewLines  = Row{0, "Valar", "Morghulis", 0, "Faceless\nMen"}
 	testRowPipes     = Row{0, "Valar", "Morghulis", 0, "Faceless|Men"}
 	testRowTabs      = Row{0, "Valar", "Morghulis", 0, "Faceless\tMen"}


### PR DESCRIPTION
Handle cases where the text in a list, progress tracker or table column contains \t or \r characters that result in the formatting being broken.