### PR TITLE
progress tracker: SetValue() to set a custom value

### DIFF
--- a/progress/tracker.go
+++ b/progress/tracker.go
@@ -80,6 +80,13 @@ func (t *Tracker) Reset() {
 	t.value = 0
 }
 
+// SetValue sets the value of the tracker and re-calculates if the tracker is
+// "done".
+func (t *Tracker) SetValue(value int64) {
+	t.Reset()
+	t.Increment(value)
+}
+
 func (t *Tracker) start() {
 	t.done = false
 	t.timeStart = time.Now()

--- a/progress/tracker_test.go
+++ b/progress/tracker_test.go
@@ -101,3 +101,17 @@ func TestTracker_Reset(t *testing.T) {
 	assert.Equal(t, time.Time{}, tracker.timeStop)
 	assert.Equal(t, int64(0), tracker.value)
 }
+
+func TestTracker_SetValue(t *testing.T) {
+	tracker := Tracker{Total: 100}
+	assert.Equal(t, int64(0), tracker.value)
+	assert.False(t, tracker.done)
+
+	tracker.SetValue(5)
+	assert.Equal(t, int64(5), tracker.value)
+	assert.False(t, tracker.done)
+
+	tracker.SetValue(tracker.Total)
+	assert.Equal(t, tracker.Total, tracker.value)
+	assert.True(t, tracker.done)
+}


### PR DESCRIPTION
## Proposed Changes
  - there are cases where a progress.Tracker's value need to be forcefully set
  - this change introduces a SetValue() function to use in such cases
