### PR TITLE
progress: handle race conditions; fixes #81

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ before_script:
 
 # CI Pipeline.
 script:
-  - make test bench
+  - make test test-race bench
   - $GOPATH/bin/goveralls -service=travis-pro -coverprofile=.coverprofile

--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,8 @@ profile:
 test: fmt lint vet cyclo
 	go test -cover -coverprofile=.coverprofile $(shell go list ./...)
 
+test-race:
+	go run -race ./cmd/demo-progress/demo.go
+
 vet:
 	go vet $(shell go list ./...)

--- a/cmd/demo-progress/demo.go
+++ b/cmd/demo-progress/demo.go
@@ -42,7 +42,7 @@ func trackSomething(pw progress.Writer, idx int64) {
 
 	pw.AppendTracker(&tracker)
 
-	c := time.Tick(time.Millisecond * 250)
+	c := time.Tick(time.Millisecond * 100)
 	for !tracker.IsDone() {
 		select {
 		case <-c:

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -41,8 +41,12 @@ func TestProgress_Length(t *testing.T) {
 	p := Progress{}
 	assert.Equal(t, 0, p.Length())
 
-	p.AppendTracker(&Tracker{})
+	p.trackersActive = append(p.trackersActive, &Tracker{})
 	assert.Equal(t, 1, p.Length())
+	p.trackersInQueue = append(p.trackersInQueue, &Tracker{})
+	assert.Equal(t, 2, p.Length())
+	p.trackersDone = append(p.trackersDone, &Tracker{})
+	assert.Equal(t, 3, p.Length())
 }
 
 func TestProgress_LengthActive(t *testing.T) {
@@ -50,9 +54,32 @@ func TestProgress_LengthActive(t *testing.T) {
 	assert.Equal(t, 0, p.Length())
 	assert.Equal(t, 0, p.LengthActive())
 
-	p.AppendTracker(&Tracker{})
+	p.trackersActive = append(p.trackersActive, &Tracker{})
 	assert.Equal(t, 1, p.Length())
 	assert.Equal(t, 1, p.LengthActive())
+	p.trackersInQueue = append(p.trackersInQueue, &Tracker{})
+	assert.Equal(t, 2, p.Length())
+	assert.Equal(t, 2, p.LengthActive())
+}
+
+func TestProgress_LengthDone(t *testing.T) {
+	p := Progress{}
+	assert.Equal(t, 0, p.Length())
+	assert.Equal(t, 0, p.LengthDone())
+
+	p.trackersDone = append(p.trackersDone, &Tracker{})
+	assert.Equal(t, 1, p.Length())
+	assert.Equal(t, 1, p.LengthDone())
+}
+
+func TestProgress_LengthInQueue(t *testing.T) {
+	p := Progress{}
+	assert.Equal(t, 0, p.Length())
+	assert.Equal(t, 0, p.LengthInQueue())
+
+	p.trackersInQueue = append(p.trackersInQueue, &Tracker{})
+	assert.Equal(t, 1, p.Length())
+	assert.Equal(t, 1, p.LengthInQueue())
 }
 
 func TestProgress_SetAutoStop(t *testing.T) {

--- a/progress/render.go
+++ b/progress/render.go
@@ -11,19 +11,24 @@ import (
 // Render renders the Progress tracker and handles all existing trackers and
 // those that are added dynamically while render is in progress.
 func (p *Progress) Render() {
-	if !p.renderInProgress {
+	if !p.IsRenderInProgress() {
 		p.initForRender()
 
 		c := time.Tick(p.updateFrequency)
 		lastRenderLength := 0
-		for p.renderInProgress = true; p.renderInProgress; {
+		p.renderInProgressMutex.Lock()
+		p.renderInProgress = true
+		p.renderInProgressMutex.Unlock()
+		for p.IsRenderInProgress() {
 			select {
 			case <-c:
-				if len(p.trackersInQueue) > 0 || len(p.trackersActive) > 0 {
+				if p.LengthActive() > 0 {
 					lastRenderLength = p.renderTrackers(lastRenderLength)
 				}
 			case <-p.done:
+				p.renderInProgressMutex.Lock()
 				p.renderInProgress = false
+				p.renderInProgressMutex.Unlock()
 			}
 		}
 	}
@@ -46,13 +51,17 @@ func (p *Progress) renderTrackers(lastRenderLength int) int {
 	for _, tracker := range trackersDone {
 		p.renderTracker(&out, tracker, renderHint{})
 	}
+	p.trackersDoneMutex.Lock()
 	p.trackersDone = append(p.trackersDone, trackersDone...)
+	p.trackersDoneMutex.Unlock()
 
 	// sort and render the active trackers
 	for _, tracker := range trackersActive {
 		p.renderTracker(&out, tracker, renderHint{})
 	}
+	p.trackersActiveMutex.Lock()
 	p.trackersActive = trackersActive
+	p.trackersActiveMutex.Unlock()
 
 	// render the overall tracker
 	p.renderTracker(&out, p.overallTracker, renderHint{isOverallTracker: true})
@@ -61,7 +70,7 @@ func (p *Progress) renderTrackers(lastRenderLength int) int {
 	p.outputWriter.Write([]byte(out.String()))
 
 	// stop if auto stop is enabled and there are no more active trackers
-	if p.autoStop && len(p.trackersInQueue) == 0 && len(p.trackersActive) == 0 {
+	if p.autoStop && p.LengthActive() == 0 {
 		p.done <- true
 	}
 
@@ -69,10 +78,12 @@ func (p *Progress) renderTrackers(lastRenderLength int) int {
 }
 
 func (p *Progress) consumeQueuedTrackers() {
-	if len(p.trackersInQueue) > 0 {
+	if p.LengthInQueue() > 0 {
+		p.trackersActiveMutex.Lock()
 		p.trackersInQueueMutex.Lock()
 		p.trackersActive = append(p.trackersActive, p.trackersInQueue...)
 		p.trackersInQueue = make([]*Tracker, 0)
+		p.trackersActiveMutex.Unlock()
 		p.trackersInQueueMutex.Unlock()
 	}
 }
@@ -84,6 +95,7 @@ func (p *Progress) extractDoneAndActiveTrackers() ([]*Tracker, []*Tracker) {
 	// separate the active and done trackers
 	var trackersActive, trackersDone []*Tracker
 	var activeTrackersProgress int64
+	p.trackersActiveMutex.RLock()
 	for _, tracker := range p.trackersActive {
 		if !tracker.IsDone() {
 			trackersActive = append(trackersActive, tracker)
@@ -92,11 +104,12 @@ func (p *Progress) extractDoneAndActiveTrackers() ([]*Tracker, []*Tracker) {
 			trackersDone = append(trackersDone, tracker)
 		}
 	}
+	p.trackersActiveMutex.RUnlock()
 	p.sortBy.Sort(trackersDone)
 	p.sortBy.Sort(trackersActive)
 
 	// calculate the overall tracker's progress value
-	p.overallTracker.value = int64(len(p.trackersDone)+len(trackersDone)) * 100
+	p.overallTracker.value = int64(p.LengthDone()+len(trackersDone)) * 100
 	p.overallTracker.value += activeTrackersProgress
 	if len(trackersActive) == 0 {
 		p.overallTracker.MarkAsDone()
@@ -105,10 +118,12 @@ func (p *Progress) extractDoneAndActiveTrackers() ([]*Tracker, []*Tracker) {
 }
 
 func (p *Progress) generateTrackerStr(t *Tracker, maxLen int) string {
+	t.mutex.Lock()
 	pDotValue := float64(t.Total) / float64(maxLen)
 	pFinishedDots := float64(t.value) / pDotValue
 	pFinishedDotsFraction := pFinishedDots - float64(int(pFinishedDots))
 	pFinishedLen := int(math.Floor(pFinishedDots))
+	t.mutex.Unlock()
 
 	var pFinished, pInProgress, pUnfinished string
 	if pFinishedLen > 0 {

--- a/progress/tracker_test.go
+++ b/progress/tracker_test.go
@@ -25,7 +25,7 @@ func TestTracker_ETA(t *testing.T) {
 
 	tracker = Tracker{Total: 100, ExpectedDuration: timeDelay}
 	tracker.start()
-	assert.True(t, tracker.ExpectedDuration > tracker.ETA())
+	assert.True(t, tracker.ETA() <= tracker.ExpectedDuration)
 	time.Sleep(timeDelay)
 	tracker.Increment(50)
 	assert.NotEqual(t, time.Duration(0), tracker.ETA())

--- a/progress/writer.go
+++ b/progress/writer.go
@@ -13,6 +13,8 @@ type Writer interface {
 	IsRenderInProgress() bool
 	Length() int
 	LengthActive() int
+	LengthDone() int
+	LengthInQueue() int
 	SetAutoStop(autoStop bool)
 	SetMessageWidth(width int)
 	SetNumTrackersExpected(numTrackers int)


### PR DESCRIPTION
@Haraguroicha found a bunch of race conditions and unsafe access of a lot of properties in Progress Writer and opened a PR with fixes for the same @ https://github.com/jedib0t/go-pretty/pull/81

The other PR is out of date with master branch and has not been re-based yet. So, this PR attempts to do the same things as #81 and some more:
   - cleaner mutex usage and new Length* interfaces
   - introduce a Make step to check for race conditions using the pre-built progress demo
   - modify the Travis config to check and fail for race conditions with every run

Fixes #81.