### PR TITLE
table: support resetting rows/headers/footers; fixes #95

### DIFF
--- a/table/render_test.go
+++ b/table/render_test.go
@@ -514,6 +514,46 @@ func TestTable_Render_Paged(t *testing.T) {
 	assert.Equal(t, expectedOut, tw.Render())
 }
 
+func TestTable_Render_Reset(t *testing.T) {
+	tw := NewWriter()
+	tw.AppendHeader(testHeader)
+	tw.AppendRows(testRows)
+	tw.AppendFooter(testFooter)
+	tw.SetStyle(StyleLight)
+
+	expectedOut := `┌─────┬────────────┬───────────┬────────┬─────────────────────────────┐
+│   # │ FIRST NAME │ LAST NAME │ SALARY │                             │
+├─────┼────────────┼───────────┼────────┼─────────────────────────────┤
+│   1 │ Arya       │ Stark     │   3000 │                             │
+│  20 │ Jon        │ Snow      │   2000 │ You know nothing, Jon Snow! │
+│ 300 │ Tyrion     │ Lannister │   5000 │                             │
+├─────┼────────────┼───────────┼────────┼─────────────────────────────┤
+│     │            │ TOTAL     │  10000 │                             │
+└─────┴────────────┴───────────┴────────┴─────────────────────────────┘`
+	assert.Equal(t, expectedOut, tw.Render())
+
+	tw.ResetFooter()
+	expectedOut = `┌─────┬────────────┬───────────┬────────┬─────────────────────────────┐
+│   # │ FIRST NAME │ LAST NAME │ SALARY │                             │
+├─────┼────────────┼───────────┼────────┼─────────────────────────────┤
+│   1 │ Arya       │ Stark     │   3000 │                             │
+│  20 │ Jon        │ Snow      │   2000 │ You know nothing, Jon Snow! │
+│ 300 │ Tyrion     │ Lannister │   5000 │                             │
+└─────┴────────────┴───────────┴────────┴─────────────────────────────┘`
+	assert.Equal(t, expectedOut, tw.Render())
+
+	tw.ResetHeader()
+	expectedOut = `┌─────┬────────┬───────────┬──────┬─────────────────────────────┐
+│   1 │ Arya   │ Stark     │ 3000 │                             │
+│  20 │ Jon    │ Snow      │ 2000 │ You know nothing, Jon Snow! │
+│ 300 │ Tyrion │ Lannister │ 5000 │                             │
+└─────┴────────┴───────────┴──────┴─────────────────────────────┘`
+	assert.Equal(t, expectedOut, tw.Render())
+
+	tw.ResetRows()
+	assert.Empty(t, tw.Render())
+}
+
 func TestTable_Render_RowPainter(t *testing.T) {
 	tw := NewWriter()
 	tw.AppendHeader(testHeader)

--- a/table/table.go
+++ b/table/table.go
@@ -131,6 +131,18 @@ func (t *Table) Length() int {
 	return len(t.rowsRaw)
 }
 
+func (t *Table) ResetFooter() {
+	t.rowsFooterRaw = nil
+}
+
+func (t *Table) ResetHeader() {
+	t.rowsHeaderRaw = nil
+}
+
+func (t *Table) ResetRows() {
+	t.rowsRaw = nil
+}
+
 // SetAlign sets the horizontal-align for each column in the (data) rows.
 //
 // Deprecated: Use SetColumnConfigs instead.
@@ -510,9 +522,6 @@ func (t *Table) initForRender() {
 	// pick a default style
 	t.Style()
 
-	// auto-index: calc the index column's max length
-	t.autoIndexVIndexMaxLength = len(fmt.Sprint(len(t.rowsRaw)))
-
 	// initialize the column configs and normalize them
 	t.initForRenderColumnConfigs()
 
@@ -589,7 +598,12 @@ func (t *Table) initForRenderColumnLengths() {
 }
 
 func (t *Table) initForRenderRows() {
-	t.rowsColors = nil
+	t.reset()
+
+	// auto-index: calc the index column's max length
+	t.autoIndexVIndexMaxLength = len(fmt.Sprint(len(t.rowsRaw)))
+
+	// stringify all the rows to make it easy to render
 	if t.rowPainter != nil {
 		t.rowsColors = make([]text.Colors, len(t.rowsRaw))
 	}
@@ -661,6 +675,19 @@ func (t *Table) render(out *strings.Builder) string {
 		_, _ = t.outputMirror.Write([]byte("\n"))
 	}
 	return outStr
+}
+
+func (t *Table) reset() {
+	t.autoIndexVIndexMaxLength = 0
+	t.columnIsNonNumeric = nil
+	t.maxColumnLengths = nil
+	t.maxRowLength = 0
+	t.numColumns = 0
+	t.rowsColors = nil
+	t.rowSeparator = nil
+	t.rows = nil
+	t.rowsFooter = nil
+	t.rowsHeader = nil
 }
 
 // renderHint has hints for the Render*() logic

--- a/table/table.go
+++ b/table/table.go
@@ -131,14 +131,17 @@ func (t *Table) Length() int {
 	return len(t.rowsRaw)
 }
 
+// ResetFooter resets and clears all the Footer rows appended earlier.
 func (t *Table) ResetFooter() {
 	t.rowsFooterRaw = nil
 }
 
+// ResetHeader resets and clears all the Header rows appended earlier.
 func (t *Table) ResetHeader() {
 	t.rowsHeaderRaw = nil
 }
 
+// ResetRows resets and clears all the rows appended earlier.
 func (t *Table) ResetRows() {
 	t.rowsRaw = nil
 }

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -134,6 +134,33 @@ func TestTable_Length(t *testing.T) {
 	assert.Equal(t, 2, table.Length())
 }
 
+func TestTable_ResetFooter(t *testing.T) {
+	table := Table{}
+	table.AppendFooter(testFooter)
+	assert.NotEmpty(t, table.rowsFooterRaw)
+
+	table.ResetFooter()
+	assert.Empty(t, table.rowsFooterRaw)
+}
+
+func TestTable_ResetHeader(t *testing.T) {
+	table := Table{}
+	table.AppendHeader(testHeader)
+	assert.NotEmpty(t, table.rowsHeaderRaw)
+
+	table.ResetHeader()
+	assert.Empty(t, table.rowsHeaderRaw)
+}
+
+func TestTable_ResetRows(t *testing.T) {
+	table := Table{}
+	table.AppendRows(testRows)
+	assert.NotEmpty(t, table.rowsRaw)
+
+	table.ResetRows()
+	assert.Empty(t, table.rowsRaw)
+}
+
 func TestTable_SetAlign(t *testing.T) {
 	table := Table{}
 	assert.Nil(t, table.align)

--- a/table/writer.go
+++ b/table/writer.go
@@ -17,6 +17,9 @@ type Writer interface {
 	RenderCSV() string
 	RenderHTML() string
 	RenderMarkdown() string
+	ResetFooter()
+	ResetHeader()
+	ResetRows()
 	SetAllowedRowLength(length int)
 	SetAutoIndex(autoIndex bool)
 	SetCaption(format string, a ...interface{})


### PR DESCRIPTION
## Proposed Changes
  - introduce Table.ResetFooter() to clear/reset footers
  - introduce Table.ResetHeader() to clear/reset headers
  - introduce Table.ResetRows() to clear/reset rows

Fixes #95.
