### PR TITLE
table: support hiding columns on render

### DIFF
--- a/table/config.go
+++ b/table/config.go
@@ -29,6 +29,11 @@ type ColumnConfig struct {
 	// ColorsHeader defines the colors to be used on the column in Header rows
 	ColorsHeader text.Colors
 
+	// Hidden when set to true will prevent the column from being rendered.
+	// This is useful in cases like needing a column for sorting, but not for
+	// display.
+	Hidden bool
+
 	// Transformer is a custom-function that changes the way the value gets
 	// rendered to the console. Refer to text/transformer.go for ready-to-use
 	// Transformer functions.

--- a/table/render_csv_test.go
+++ b/table/render_csv_test.go
@@ -36,6 +36,58 @@ func TestTable_RenderCSV_Empty(t *testing.T) {
 	assert.Empty(t, tw.RenderCSV())
 }
 
+func TestTable_RenderCSV_HiddenColumns(t *testing.T) {
+	tw := NewWriter()
+	tw.AppendHeader(testHeader)
+	tw.AppendRows(testRows)
+	tw.AppendFooter(testFooter)
+
+	// ensure sorting is done before hiding the columns
+	tw.SortBy([]SortBy{
+		{Name: "Salary", Mode: DscNumeric},
+	})
+
+	t.Run("every column hidden", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{0, 1, 2, 3, 4}))
+
+		expectedOut := ``
+		assert.Equal(t, expectedOut, tw.RenderCSV())
+	})
+
+	t.Run("first column hidden", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{0}))
+
+		expectedOut := `First Name,Last Name,Salary,
+>>Tyrion,Lannister<<,5013,
+>>Arya,Stark<<,3013,
+>>Jon,Snow<<,2013,"~You know nothing\, Jon Snow!~"
+,Total,10000,`
+		assert.Equal(t, expectedOut, tw.RenderCSV())
+	})
+
+	t.Run("column hidden in the middle", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{1}))
+
+		expectedOut := `#,Last Name,Salary,
+307,Lannister<<,5013,
+8,Stark<<,3013,
+27,Snow<<,2013,"~You know nothing\, Jon Snow!~"
+,Total,10000,`
+		assert.Equal(t, expectedOut, tw.RenderCSV())
+	})
+
+	t.Run("last column hidden", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{4}))
+
+		expectedOut := `#,First Name,Last Name,Salary
+307,>>Tyrion,Lannister<<,5013
+8,>>Arya,Stark<<,3013
+27,>>Jon,Snow<<,2013
+,,Total,10000`
+		assert.Equal(t, expectedOut, tw.RenderCSV())
+	})
+}
+
 func TestTable_RenderCSV_Sorted(t *testing.T) {
 	tw := NewWriter()
 	tw.AppendHeader(testHeader)

--- a/table/render_html_test.go
+++ b/table/render_html_test.go
@@ -156,7 +156,158 @@ func TestTable_RenderHTML_Empty(t *testing.T) {
 	assert.Empty(t, tw.RenderHTML())
 }
 
-func TestTable_RendeHTML_Sorted(t *testing.T) {
+func TestTable_RenderHTML_HiddenColumns(t *testing.T) {
+	tw := NewWriter()
+	tw.AppendHeader(testHeader)
+	tw.AppendRows(testRows)
+	tw.AppendFooter(testFooter)
+
+	// ensure sorting is done before hiding the columns
+	tw.SortBy([]SortBy{
+		{Name: "Salary", Mode: DscNumeric},
+	})
+
+	t.Run("every column hidden", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{0, 1, 2, 3, 4}))
+
+		expectedOut := ``
+		assert.Equal(t, expectedOut, tw.RenderHTML())
+	})
+
+	t.Run("first column hidden", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{0}))
+
+		expectedOut := `<table class="go-pretty-table">
+  <thead>
+  <tr>
+    <th>First Name</th>
+    <th>Last Name</th>
+    <th align="right">Salary</th>
+    <th>&nbsp;</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>&gt;&gt;Tyrion</td>
+    <td>Lannister&lt;&lt;</td>
+    <td align="right">5013</td>
+    <td>&nbsp;</td>
+  </tr>
+  <tr>
+    <td>&gt;&gt;Arya</td>
+    <td>Stark&lt;&lt;</td>
+    <td align="right">3013</td>
+    <td>&nbsp;</td>
+  </tr>
+  <tr>
+    <td>&gt;&gt;Jon</td>
+    <td>Snow&lt;&lt;</td>
+    <td align="right">2013</td>
+    <td>~You know nothing, Jon Snow!~</td>
+  </tr>
+  </tbody>
+  <tfoot>
+  <tr>
+    <td>&nbsp;</td>
+    <td>Total</td>
+    <td align="right">10000</td>
+    <td>&nbsp;</td>
+  </tr>
+  </tfoot>
+</table>`
+		assert.Equal(t, expectedOut, tw.RenderHTML())
+	})
+
+	t.Run("column hidden in the middle", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{1}))
+
+		expectedOut := `<table class="go-pretty-table">
+  <thead>
+  <tr>
+    <th align="right">#</th>
+    <th>Last Name</th>
+    <th align="right">Salary</th>
+    <th>&nbsp;</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td align="right">307</td>
+    <td>Lannister&lt;&lt;</td>
+    <td align="right">5013</td>
+    <td>&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">8</td>
+    <td>Stark&lt;&lt;</td>
+    <td align="right">3013</td>
+    <td>&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">27</td>
+    <td>Snow&lt;&lt;</td>
+    <td align="right">2013</td>
+    <td>~You know nothing, Jon Snow!~</td>
+  </tr>
+  </tbody>
+  <tfoot>
+  <tr>
+    <td align="right">&nbsp;</td>
+    <td>Total</td>
+    <td align="right">10000</td>
+    <td>&nbsp;</td>
+  </tr>
+  </tfoot>
+</table>`
+		assert.Equal(t, expectedOut, tw.RenderHTML())
+	})
+
+	t.Run("last column hidden", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{4}))
+
+		expectedOut := `<table class="go-pretty-table">
+  <thead>
+  <tr>
+    <th align="right">#</th>
+    <th>First Name</th>
+    <th>Last Name</th>
+    <th align="right">Salary</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td align="right">307</td>
+    <td>&gt;&gt;Tyrion</td>
+    <td>Lannister&lt;&lt;</td>
+    <td align="right">5013</td>
+  </tr>
+  <tr>
+    <td align="right">8</td>
+    <td>&gt;&gt;Arya</td>
+    <td>Stark&lt;&lt;</td>
+    <td align="right">3013</td>
+  </tr>
+  <tr>
+    <td align="right">27</td>
+    <td>&gt;&gt;Jon</td>
+    <td>Snow&lt;&lt;</td>
+    <td align="right">2013</td>
+  </tr>
+  </tbody>
+  <tfoot>
+  <tr>
+    <td align="right">&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>Total</td>
+    <td align="right">10000</td>
+  </tr>
+  </tfoot>
+</table>`
+		assert.Equal(t, expectedOut, tw.RenderHTML())
+	})
+}
+
+func TestTable_RenderHTML_Sorted(t *testing.T) {
 	tw := NewWriter()
 	tw.AppendHeader(testHeader)
 	tw.AppendRows(testRows)

--- a/table/render_markdown_test.go
+++ b/table/render_markdown_test.go
@@ -35,6 +35,61 @@ func TestTable_RenderMarkdown_Empty(t *testing.T) {
 	assert.Empty(t, tw.RenderMarkdown())
 }
 
+func TestTable_RenderMarkdown_HiddenColumns(t *testing.T) {
+	tw := NewWriter()
+	tw.AppendHeader(testHeader)
+	tw.AppendRows(testRows)
+	tw.AppendFooter(testFooter)
+
+	// ensure sorting is done before hiding the columns
+	tw.SortBy([]SortBy{
+		{Name: "Salary", Mode: DscNumeric},
+	})
+
+	t.Run("every column hidden", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{0, 1, 2, 3, 4}))
+
+		expectedOut := ``
+		assert.Equal(t, expectedOut, tw.RenderMarkdown())
+	})
+
+	t.Run("first column hidden", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{0}))
+
+		expectedOut := `| First Name | Last Name | Salary |  |
+| --- | --- | ---:| --- |
+| >>Tyrion | Lannister<< | 5013 |  |
+| >>Arya | Stark<< | 3013 |  |
+| >>Jon | Snow<< | 2013 | ~You know nothing, Jon Snow!~ |
+|  | Total | 10000 |  |`
+		assert.Equal(t, expectedOut, tw.RenderMarkdown())
+	})
+
+	t.Run("column hidden in the middle", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{1}))
+
+		expectedOut := `| # | Last Name | Salary |  |
+| ---:| --- | ---:| --- |
+| 307 | Lannister<< | 5013 |  |
+| 8 | Stark<< | 3013 |  |
+| 27 | Snow<< | 2013 | ~You know nothing, Jon Snow!~ |
+|  | Total | 10000 |  |`
+		assert.Equal(t, expectedOut, tw.RenderMarkdown())
+	})
+
+	t.Run("last column hidden", func(t *testing.T) {
+		tw.SetColumnConfigs(generateColumnConfigsWithHiddenColumns([]int{4}))
+
+		expectedOut := `| # | First Name | Last Name | Salary |
+| ---:| --- | --- | ---:|
+| 307 | >>Tyrion | Lannister<< | 5013 |
+| 8 | >>Arya | Stark<< | 3013 |
+| 27 | >>Jon | Snow<< | 2013 |
+|  |  | Total | 10000 |`
+		assert.Equal(t, expectedOut, tw.RenderMarkdown())
+	})
+}
+
 func TestTable_RendeMarkdown_Sorted(t *testing.T) {
 	tw := NewWriter()
 	tw.AppendHeader(testHeader)


### PR DESCRIPTION
## Proposed Changes
  - introduce ColumnConfig.Hidden property to hide columns while rendering
    - this help the use-case where someone wants to use a column for sorting the content, but does not want it rendered in any of the formats

Fixes #90.
