### PR TITLE
update to go-runewidth v0.0.9

### DIFF
--- a/cmd/demo-table/demo.go
+++ b/cmd/demo-table/demo.go
@@ -671,6 +671,30 @@ func demoTableFeatures() {
 	//==========================================================================
 }
 
+func demoTableEmoji() {
+	styles := []table.Style{
+		table.StyleDefault,
+		table.StyleLight,
+		table.StyleColoredBright,
+	}
+	for _, style := range styles {
+		tw := table.NewWriter()
+		tw.AppendHeader(table.Row{"Key", "Value"})
+		tw.AppendRows([]table.Row{
+			{"Emoji 1 🥰", 1000},
+			{"Emoji 2 ⚔️", 2000},
+			{"Emoji 3 🎁", 3000},
+			{"Emoji 4 ツ", 4000},
+		})
+		tw.AppendFooter(table.Row{"Total", 10000})
+		tw.SetAutoIndex(true)
+		tw.SetStyle(style)
+
+		fmt.Println(tw.Render())
+		fmt.Println()
+	}
+}
+
 func main() {
 	demoWhat := "features"
 	if len(os.Args) > 1 {
@@ -680,6 +704,8 @@ func main() {
 	switch strings.ToLower(demoWhat) {
 	case "colors":
 		demoTableColors()
+	case "emoji":
+		demoTableEmoji()
 	default:
 		demoTableFeatures()
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-openapi/errors v0.19.0 // indirect
 	github.com/go-openapi/strfmt v0.19.0
 	github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983 // indirect
-	github.com/mattn/go-runewidth v0.0.4
+	github.com/mattn/go-runewidth v0.0.9
 	github.com/pkg/profile v1.2.1
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20180816055513-1c9583448a9c

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983 h1:wL11wNW7dhKIcRC
 github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pkg/profile v1.2.1 h1:F++O52m40owAmADcojzM+9gyjmMOY/T4oYJkgFDH8RE=


### PR DESCRIPTION
## Proposed Changes
  - update to go-runewidth v0.0.9
  - add a new "emoji demo" to table demo

Execution sample:
![table-emoji](https://user-images.githubusercontent.com/38574447/81478808-788fb680-91d4-11ea-8b31-99e406bc560d.png)