### PR TITLE
table: fix auto-index for CSV/HTML/Markdown modes; fixes #108

### DIFF
--- a/table/render.go
+++ b/table/render.go
@@ -360,7 +360,7 @@ func (t *Table) renderRowsHeader(out *strings.Builder) {
 		if len(t.rowsHeader) > 0 {
 			t.renderRows(out, t.rowsHeader, renderHint{isHeaderRow: true})
 		} else if t.autoIndex {
-			t.renderRow(out, t.getAutoIndexColumnIDs(), renderHint{isHeaderRow: true})
+			t.renderRow(out, t.getAutoIndexColumnIDs(), renderHint{isAutoIndexRow: true, isHeaderRow: true})
 		}
 		t.renderRowSeparator(out, renderHint{isHeaderRow: true, isSeparatorRow: true})
 	}

--- a/table/render_csv_test.go
+++ b/table/render_csv_test.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,32 @@ This is known."
 0,Valar,Morghulis,0,Faceless    Men
 ,,Total,10000,
 A Song of Ice and Fire`
+	assert.Equal(t, expectedOut, tw.RenderCSV())
+}
 
+func TestTable_RenderCSV_AutoIndex(t *testing.T) {
+	tw := NewWriter()
+	for rowIdx := 0; rowIdx < 10; rowIdx++ {
+		row := make(Row, 10)
+		for colIdx := 0; colIdx < 10; colIdx++ {
+			row[colIdx] = fmt.Sprintf("%s%d", AutoIndexColumnID(colIdx), rowIdx+1)
+		}
+		tw.AppendRow(row)
+	}
+	tw.SetAutoIndex(true)
+	tw.SetStyle(StyleLight)
+
+	expectedOut := `,A,B,C,D,E,F,G,H,I,J
+1,A1,B1,C1,D1,E1,F1,G1,H1,I1,J1
+2,A2,B2,C2,D2,E2,F2,G2,H2,I2,J2
+3,A3,B3,C3,D3,E3,F3,G3,H3,I3,J3
+4,A4,B4,C4,D4,E4,F4,G4,H4,I4,J4
+5,A5,B5,C5,D5,E5,F5,G5,H5,I5,J5
+6,A6,B6,C6,D6,E6,F6,G6,H6,I6,J6
+7,A7,B7,C7,D7,E7,F7,G7,H7,I7,J7
+8,A8,B8,C8,D8,E8,F8,G8,H8,I8,J8
+9,A9,B9,C9,D9,E9,F9,G9,H9,I9,J9
+10,A10,B10,C10,D10,E10,F10,G10,H10,I10,J10`
 	assert.Equal(t, expectedOut, tw.RenderCSV())
 }
 

--- a/table/render_html_test.go
+++ b/table/render_html_test.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/jedib0t/go-pretty/text"
@@ -17,8 +18,16 @@ func TestTable_RenderHTML(t *testing.T) {
 		{Name: "Salary", VAlign: text.VAlignBottom},
 		{Number: 5, VAlign: text.VAlignBottom},
 	})
+	tw.SetTitle(testTitle1)
+	tw.SetCaption(testCaption)
+	tw.Style().Title = TitleOptions{
+		Align:  text.AlignLeft,
+		Colors: text.Colors{text.BgBlack, text.Bold, text.FgHiBlue},
+		Format: text.FormatTitle,
+	}
 
 	expectedOut := `<table class="go-pretty-table">
+  <caption class="title" align="left" class="bg-black bold fg-hi-blue">Game Of Thrones</caption>
   <thead>
   <tr>
     <th align="right">#</th>
@@ -67,8 +76,53 @@ func TestTable_RenderHTML(t *testing.T) {
     <td>&nbsp;</td>
   </tr>
   </tfoot>
+  <caption class="caption" style="caption-side: bottom;">A Song of Ice and Fire</caption>
 </table>`
 
+	assert.Equal(t, expectedOut, tw.RenderHTML())
+}
+func TestTable_RenderHTML_AutoIndex(t *testing.T) {
+	tw := NewWriter()
+	for rowIdx := 0; rowIdx < 3; rowIdx++ {
+		row := make(Row, 3)
+		for colIdx := 0; colIdx < 3; colIdx++ {
+			row[colIdx] = fmt.Sprintf("%s%d", AutoIndexColumnID(colIdx), rowIdx+1)
+		}
+		tw.AppendRow(row)
+	}
+	tw.SetAutoIndex(true)
+	tw.SetStyle(StyleLight)
+
+	expectedOut := `<table class="go-pretty-table">
+  <thead>
+  <tr>
+    <th>&nbsp;</th>
+    <th align="center">A</th>
+    <th align="center">B</th>
+    <th align="center">C</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>1</td>
+    <td>A1</td>
+    <td>B1</td>
+    <td>C1</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>A2</td>
+    <td>B2</td>
+    <td>C2</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>A3</td>
+    <td>B3</td>
+    <td>C3</td>
+  </tr>
+  </tbody>
+</table>`
 	assert.Equal(t, expectedOut, tw.RenderHTML())
 }
 
@@ -110,6 +164,7 @@ func TestTable_RenderHTML_Colored(t *testing.T) {
 	})
 
 	expectedOut := `<table class="go-pretty-table">
+  <caption class="title">Game of Thrones</caption>
   <thead>
   <tr>
     <th align="right" class="bg-white fg-black">#</th>
@@ -158,6 +213,7 @@ func TestTable_RenderHTML_Colored(t *testing.T) {
     <td>&nbsp;</td>
   </tr>
   </tfoot>
+  <caption class="caption" style="caption-side: bottom;">A Song of Ice and Fire</caption>
 </table>`
 
 	assert.Equal(t, expectedOut, tw.RenderHTML())

--- a/table/render_markdown.go
+++ b/table/render_markdown.go
@@ -1,6 +1,9 @@
 package table
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // RenderMarkdown renders the Table in Markdown format. Example:
 //  | # | First Name | Last Name | Salary |  |
@@ -14,62 +17,94 @@ func (t *Table) RenderMarkdown() string {
 
 	var out strings.Builder
 	if t.numColumns > 0 {
-		if t.title != "" {
-			out.WriteString("# ")
-			out.WriteString(t.title)
-		}
-		t.markdownRenderRows(&out, t.rowsHeader, renderHint{isHeaderRow: true})
+		t.markdownRenderTitle(&out)
+		t.markdownRenderRowsHeader(&out)
 		t.markdownRenderRows(&out, t.rows, renderHint{})
-		t.markdownRenderRows(&out, t.rowsFooter, renderHint{isFooterRow: true})
-		if t.caption != "" {
-			out.WriteRune('\n')
-			out.WriteRune('_')
-			out.WriteString(t.caption)
-			out.WriteRune('_')
-		}
+		t.markdownRenderRowsFooter(&out)
+		t.markdownRenderCaption(&out)
 	}
 	return t.render(&out)
 }
 
-func (t *Table) markdownRenderRow(out *strings.Builder, row rowStr, hint renderHint) {
-	if len(row) > 0 {
-		// when working on line number 2 or more, insert a newline first
-		if out.Len() > 0 {
-			out.WriteRune('\n')
-		}
+func (t *Table) markdownRenderCaption(out *strings.Builder) {
+	if t.caption != "" {
+		out.WriteRune('\n')
+		out.WriteRune('_')
+		out.WriteString(t.caption)
+		out.WriteRune('_')
+	}
+}
 
-		// render each column up to the max. columns seen in all the rows
-		out.WriteRune('|')
-		for colIdx := 0; colIdx < t.numColumns; colIdx++ {
+func (t *Table) markdownRenderRow(out *strings.Builder, row rowStr, hint renderHint) {
+	// when working on line number 2 or more, insert a newline first
+	if out.Len() > 0 {
+		out.WriteRune('\n')
+	}
+
+	// render each column up to the max. columns seen in all the rows
+	out.WriteRune('|')
+	for colIdx := 0; colIdx < t.numColumns; colIdx++ {
+		// auto-index column
+		if colIdx == 0 && t.autoIndex {
+			out.WriteRune(' ')
 			if hint.isSeparatorRow {
-				out.WriteString(t.getAlign(colIdx, hint).MarkdownProperty())
-			} else {
-				var colStr string
-				if colIdx < len(row) {
-					colStr = row[colIdx]
-				}
-				out.WriteRune(' ')
-				if strings.Contains(colStr, "|") {
-					colStr = strings.Replace(colStr, "|", "\\|", -1)
-				}
-				if strings.Contains(colStr, "\n") {
-					colStr = strings.Replace(colStr, "\n", "<br/>", -1)
-				}
-				out.WriteString(colStr)
-				out.WriteRune(' ')
+				out.WriteString("--- ")
+			} else if hint.isRegularRow() {
+				out.WriteString(fmt.Sprintf("%d ", hint.rowNumber))
 			}
 			out.WriteRune('|')
 		}
+
+		if hint.isSeparatorRow {
+			out.WriteString(t.getAlign(colIdx, hint).MarkdownProperty())
+		} else {
+			var colStr string
+			if colIdx < len(row) {
+				colStr = row[colIdx]
+			}
+			out.WriteRune(' ')
+			if strings.Contains(colStr, "|") {
+				colStr = strings.Replace(colStr, "|", "\\|", -1)
+			}
+			if strings.Contains(colStr, "\n") {
+				colStr = strings.Replace(colStr, "\n", "<br/>", -1)
+			}
+			out.WriteString(colStr)
+			out.WriteRune(' ')
+		}
+		out.WriteRune('|')
 	}
 }
 
 func (t *Table) markdownRenderRows(out *strings.Builder, rows []rowStr, hint renderHint) {
 	if len(rows) > 0 {
 		for idx, row := range rows {
-			t.markdownRenderRow(out, row, renderHint{})
+			hint.rowNumber = idx + 1
+			t.markdownRenderRow(out, row, hint)
+
 			if idx == len(rows)-1 && hint.isHeaderRow {
 				t.markdownRenderRow(out, t.rowSeparator, renderHint{isSeparatorRow: true})
 			}
 		}
+	}
+}
+
+func (t *Table) markdownRenderRowsFooter(out *strings.Builder) {
+	t.markdownRenderRows(out, t.rowsFooter, renderHint{isFooterRow: true})
+
+}
+
+func (t *Table) markdownRenderRowsHeader(out *strings.Builder) {
+	if len(t.rowsHeader) > 0 {
+		t.markdownRenderRows(out, t.rowsHeader, renderHint{isHeaderRow: true})
+	} else if t.autoIndex {
+		t.markdownRenderRows(out, []rowStr{t.getAutoIndexColumnIDs()}, renderHint{isAutoIndexRow: true, isHeaderRow: true})
+	}
+}
+
+func (t *Table) markdownRenderTitle(out *strings.Builder) {
+	if t.title != "" {
+		out.WriteString("# ")
+		out.WriteString(t.title)
 	}
 }

--- a/table/render_markdown_test.go
+++ b/table/render_markdown_test.go
@@ -1,6 +1,8 @@
 package table
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,6 +29,34 @@ func TestTable_RenderMarkdown(t *testing.T) {
 |  |  | Total | 10000 |  |
 _A Song of Ice and Fire_`
 
+	assert.Equal(t, expectedOut, tw.RenderMarkdown())
+}
+
+func TestTable_RenderMarkdown_AutoIndex(t *testing.T) {
+	tw := NewWriter()
+	for rowIdx := 0; rowIdx < 10; rowIdx++ {
+		row := make(Row, 10)
+		for colIdx := 0; colIdx < 10; colIdx++ {
+			row[colIdx] = fmt.Sprintf("%s%d", AutoIndexColumnID(colIdx), rowIdx+1)
+		}
+		tw.AppendRow(row)
+	}
+	tw.SetAutoIndex(true)
+	tw.SetStyle(StyleLight)
+	tw.SetOutputMirror(os.Stdout)
+
+	expectedOut := `| | A | B | C | D | E | F | G | H | I | J |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | A1 | B1 | C1 | D1 | E1 | F1 | G1 | H1 | I1 | J1 |
+| 2 | A2 | B2 | C2 | D2 | E2 | F2 | G2 | H2 | I2 | J2 |
+| 3 | A3 | B3 | C3 | D3 | E3 | F3 | G3 | H3 | I3 | J3 |
+| 4 | A4 | B4 | C4 | D4 | E4 | F4 | G4 | H4 | I4 | J4 |
+| 5 | A5 | B5 | C5 | D5 | E5 | F5 | G5 | H5 | I5 | J5 |
+| 6 | A6 | B6 | C6 | D6 | E6 | F6 | G6 | H6 | I6 | J6 |
+| 7 | A7 | B7 | C7 | D7 | E7 | F7 | G7 | H7 | I7 | J7 |
+| 8 | A8 | B8 | C8 | D8 | E8 | F8 | G8 | H8 | I8 | J8 |
+| 9 | A9 | B9 | C9 | D9 | E9 | F9 | G9 | H9 | I9 | J9 |
+| 10 | A10 | B10 | C10 | D10 | E10 | F10 | G10 | H10 | I10 | J10 |`
 	assert.Equal(t, expectedOut, tw.RenderMarkdown())
 }
 

--- a/table/render_test.go
+++ b/table/render_test.go
@@ -2,7 +2,6 @@ package table
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -316,7 +315,6 @@ func TestTable_Render_Colored(t *testing.T) {
 	tw.Style().Options.SeparateFooter = true
 	tw.Style().Options.SeparateHeader = true
 	tw.Style().Options.SeparateRows = true
-	tw.SetOutputMirror(os.Stdout)
 
 	expectedOut := []string{
 		"\x1b[106;30m+\x1b[0m\x1b[106;30m---\x1b[0m\x1b[106;30m+\x1b[0m\x1b[106;30m-----\x1b[0m\x1b[106;30m+\x1b[0m\x1b[106;30m------------\x1b[0m\x1b[106;30m+\x1b[0m\x1b[106;30m-----------\x1b[0m\x1b[106;30m+\x1b[0m\x1b[106;30m--------\x1b[0m\x1b[106;30m+\x1b[0m\x1b[106;30m-----------------------------\x1b[0m\x1b[106;30m+\x1b[0m",

--- a/table/table.go
+++ b/table/table.go
@@ -291,16 +291,20 @@ func (t *Table) getAlign(colIdx int, hint renderHint) text.Align {
 			align = cfg.Align
 		}
 	}
-	if align == text.AlignDefault && !t.columnIsNonNumeric[colIdx] {
-		align = text.AlignRight
+	if align == text.AlignDefault {
+		if !t.columnIsNonNumeric[colIdx] {
+			align = text.AlignRight
+		} else if hint.isAutoIndexRow {
+			align = text.AlignCenter
+		}
 	}
 	return align
 }
 
 func (t *Table) getAutoIndexColumnIDs() rowStr {
 	row := make(rowStr, t.numColumns)
-	for colIdx, maxColumnLength := range t.maxColumnLengths {
-		row[colIdx] = text.AlignCenter.Apply(AutoIndexColumnID(colIdx), maxColumnLength)
+	for colIdx := range row {
+		row[colIdx] = AutoIndexColumnID(colIdx)
 	}
 	return row
 }
@@ -647,6 +651,7 @@ func (t *Table) reset() {
 // renderHint has hints for the Render*() logic
 type renderHint struct {
 	isAutoIndexColumn bool // auto-index column?
+	isAutoIndexRow    bool // auto-index row?
 	isBorderBottom    bool // bottom-border?
 	isBorderTop       bool // top-border?
 	isFirstRow        bool // first-row of header/footer/regular-rows?

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -210,7 +210,7 @@ func TestTable_SetAutoIndex(t *testing.T) {
 
 	table.SetAutoIndex(true)
 	expectedOut = `(---^-----^--------^-----------^------^-----------------------------)
-[< >|< A >|<   B  >|<    C    >|<  D >|<             E             >]
+[< >|<  A>|<   B  >|<    C    >|<   D>|<             E             >]
 {---+-----+--------+-----------+------+-----------------------------}
 [<1>|<  1>|<Arya  >|<Stark    >|<3000>|<                           >]
 [<2>|< 20>|<Jon   >|<Snow     >|<2000>|<You know nothing, Jon Snow!>]


### PR DESCRIPTION
## Proposed Changes
  - table: support auto-index for CSV/HTML/Markdown modes
  - table: HTML: support title/caption using the \<caption\> tag

Fixes #108.
