### PR TITLE
go.mod compatible versioning (v6 in import paths)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/jedib0t/go-pretty)](https://goreportcard.com/report/github.com/jedib0t/go-pretty)
 [![GoDoc](https://godoc.org/github.com/jedib0t/go-pretty?status.svg)](https://godoc.org/github.com/jedib0t/go-pretty)
 
-
-Utilities to prettify console output of tables, lists, text, etc.
+Utilities to prettify console output of tables, lists, progress-bars, text, etc.
 
 ## Table
 
@@ -100,4 +99,42 @@ BenchmarkTable_Render-2           	   27208	     44154 ns/op	    5616 B/op	     
 BenchmarkTable_RenderCSV-2        	  108732	     11059 ns/op	    2624 B/op	      46 allocs/op
 BenchmarkTable_RenderHTML-2       	   88633	     13425 ns/op	    4080 B/op	      45 allocs/op
 BenchmarkTable_RenderMarkdown-2   	  107420	     10991 ns/op	    2560 B/op	      44 allocs/op
+```
+
+## A note about v6.0.0 and above ...
+
+To make `go-pretty` completely compatible with `go mod`, versions `v6.0.0` and
+above will include changes that are known to break `dep` support. As far as I
+can tell, `dep` is looking for funding right now and is not being actively
+developed or maintained and has an interoperability issues with how `go mod`
+deals with package versioning.
+
+If you want to continue to use `dep`, versions `v5.x.x` and below should
+continue to work. If `dep` maintainers can merge the code proposed in
+[PR#1963](https://github.com/golang/dep/pull/1963), it should make `v6.0.0` and
+above usable too. Given that the PR has not been merged since July 2018, I am
+not too hopeful. :disappointed:
+
+To use `v6.0.0` (or newer version) of this library, you'd have to modify the
+import paths from something like:
+```golang
+    "github.com/jedib0t/go-pretty/list"
+    "github.com/jedib0t/go-pretty/progress"
+    "github.com/jedib0t/go-pretty/table"
+    "github.com/jedib0t/go-pretty/text"
+```
+to:
+```golang
+    "github.com/jedib0t/go-pretty/v6/list"
+    "github.com/jedib0t/go-pretty/v6/progress"
+    "github.com/jedib0t/go-pretty/v6/table"
+    "github.com/jedib0t/go-pretty/v6/text"
+```
+
+I'd recommend you fire up your favorite IDE and do a mass search and replace for
+all occurrences of `jedib0t/go-pretty/` to `jedib0t/go-pretty/v6/`. If you are
+on a system with access to `find`, `grep`, `xargs` and `sed`, you could just run
+the following from within your code folder to do the same:
+```
+find . -type f -name "*.go" | grep -v vendor | xargs sed -i 's/jedib0t\/go-pretty\//jedib0t\/go-pretty\/v6\//'g
 ```

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ BenchmarkTable_RenderMarkdown-2   	  107420	     10991 ns/op	    2560 B/op	     
 To make `go-pretty` completely compatible with `go mod`, versions `v6.0.0` and
 above will include changes that are known to break `dep` support. As far as I
 can tell, `dep` is looking for funding right now and is not being actively
-developed or maintained and has an interoperability issues with how `go mod`
+developed or maintained and has an interoperability issue with how `go mod`
 deals with package versioning.
 
-If you want to continue to use `dep`, versions `v5.x.x` and below should
+If you want to continue to use `dep`, versions `v5.1.x` and below should
 continue to work. If `dep` maintainers can merge the code proposed in
 [PR#1963](https://github.com/golang/dep/pull/1963), it should make `v6.0.0` and
 above usable too. Given that the PR has not been merged since July 2018, I am

--- a/bench_test.go
+++ b/bench_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jedib0t/go-pretty/list"
-	"github.com/jedib0t/go-pretty/progress"
-	"github.com/jedib0t/go-pretty/table"
+	"github.com/jedib0t/go-pretty/v6/list"
+	"github.com/jedib0t/go-pretty/v6/progress"
+	"github.com/jedib0t/go-pretty/v6/table"
 )
 
 var (

--- a/cmd/demo-list/demo.go
+++ b/cmd/demo-list/demo.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jedib0t/go-pretty/list"
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/list"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 func demoPrint(title string, content string, prefix string) {

--- a/cmd/demo-progress/demo.go
+++ b/cmd/demo-progress/demo.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jedib0t/go-pretty/progress"
+	"github.com/jedib0t/go-pretty/v6/progress"
 )
 
 var (

--- a/cmd/demo-table/demo.go
+++ b/cmd/demo-table/demo.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jedib0t/go-pretty/table"
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 func demoTableColors() {

--- a/cmd/profile-list/profile.go
+++ b/cmd/profile-list/profile.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/jedib0t/go-pretty/list"
+	"github.com/jedib0t/go-pretty/v6/list"
 	"github.com/pkg/profile"
 )
 

--- a/cmd/profile-progress/profile.go
+++ b/cmd/profile-progress/profile.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/jedib0t/go-pretty/progress"
+	"github.com/jedib0t/go-pretty/v6/progress"
 	"github.com/pkg/profile"
 )
 

--- a/cmd/profile-table/profile.go
+++ b/cmd/profile-table/profile.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/jedib0t/go-pretty/table"
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/pkg/profile"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jedib0t/go-pretty
+module github.com/jedib0t/go-pretty/v6
 
 go 1.13
 

--- a/list/style.go
+++ b/list/style.go
@@ -1,6 +1,6 @@
 package list
 
-import "github.com/jedib0t/go-pretty/text"
+import "github.com/jedib0t/go-pretty/v6/text"
 
 // Style declares how to render the List (items).
 type Style struct {

--- a/list/writer_test.go
+++ b/list/writer_test.go
@@ -3,7 +3,7 @@ package list
 import (
 	"fmt"
 
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 func Example() {

--- a/progress/render.go
+++ b/progress/render.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 // Render renders the Progress tracker and handles all existing trackers and

--- a/progress/style.go
+++ b/progress/style.go
@@ -3,7 +3,7 @@ package progress
 import (
 	"time"
 
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 // Style declares how to render the Progress/Trackers.

--- a/table/config.go
+++ b/table/config.go
@@ -1,7 +1,7 @@
 package table
 
 import (
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 // ColumnConfig contains configurations that determine and modify the way the

--- a/table/config_test.go
+++ b/table/config_test.go
@@ -3,7 +3,7 @@ package table
 import (
 	"testing"
 
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/table/render.go
+++ b/table/render.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 // Render renders the Table in a human-readable "pretty" format. Example:

--- a/table/render_html_test.go
+++ b/table/render_html_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/table/render_test.go
+++ b/table/render_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/table/style.go
+++ b/table/style.go
@@ -1,7 +1,7 @@
 package table
 
 import (
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 // Style declares how to render the Table and provides very fine-grained control

--- a/table/table.go
+++ b/table/table.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 // Row defines a single row in the Table.

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/table/writer_test.go
+++ b/table/writer_test.go
@@ -3,7 +3,7 @@ package table
 import (
 	"fmt"
 
-	"github.com/jedib0t/go-pretty/text"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 func Example_simple() {


### PR DESCRIPTION
Current versioning scheme may work with dep, but not with `go mod`. The import path that `go mod` expects beyond major version v1 is `jedib0t/go-pretty/v6/table` instead of just `jedib0t/go-pretty/table`.

- Change go.mod package path to have a `v6` prefix
- Update all code to refer to the `v6` path in the imports
- Add a note about this in the main README

Fixes #115.