### PR TITLE
table: auto-index should not be applied on footer; fixes #108

### DIFF
--- a/table/render_csv_test.go
+++ b/table/render_csv_test.go
@@ -40,6 +40,13 @@ func TestTable_RenderCSV_AutoIndex(t *testing.T) {
 		}
 		tw.AppendRow(row)
 	}
+	for rowIdx := 0; rowIdx < 1; rowIdx++ {
+		row := make(Row, 10)
+		for colIdx := 0; colIdx < 10; colIdx++ {
+			row[colIdx] = AutoIndexColumnID(colIdx) + "F"
+		}
+		tw.AppendFooter(row)
+	}
 	tw.SetAutoIndex(true)
 	tw.SetStyle(StyleLight)
 
@@ -53,7 +60,8 @@ func TestTable_RenderCSV_AutoIndex(t *testing.T) {
 7,A7,B7,C7,D7,E7,F7,G7,H7,I7,J7
 8,A8,B8,C8,D8,E8,F8,G8,H8,I8,J8
 9,A9,B9,C9,D9,E9,F9,G9,H9,I9,J9
-10,A10,B10,C10,D10,E10,F10,G10,H10,I10,J10`
+10,A10,B10,C10,D10,E10,F10,G10,H10,I10,J10
+,AF,BF,CF,DF,EF,FF,GF,HF,IF,JF`
 	assert.Equal(t, expectedOut, tw.RenderCSV())
 }
 

--- a/table/render_html.go
+++ b/table/render_html.go
@@ -93,6 +93,8 @@ func (t *Table) htmlRenderRow(out *strings.Builder, row rowStr, hint renderHint)
 		if colIdx == 0 && t.autoIndex {
 			if hint.isHeaderRow {
 				out.WriteString("    <th>&nbsp;</th>\n")
+			} else if hint.isFooterRow {
+				out.WriteString("    <td>&nbsp;</td>\n")
 			} else {
 				out.WriteString(fmt.Sprintf("    <td>%d</td>\n", hint.rowNumber))
 			}

--- a/table/render_html.go
+++ b/table/render_html.go
@@ -96,7 +96,7 @@ func (t *Table) htmlRenderRow(out *strings.Builder, row rowStr, hint renderHint)
 			} else if hint.isFooterRow {
 				out.WriteString("    <td>&nbsp;</td>\n")
 			} else {
-				out.WriteString(fmt.Sprintf("    <td>%d</td>\n", hint.rowNumber))
+				out.WriteString(fmt.Sprintf("    <td align=\"right\">%d</td>\n", hint.rowNumber))
 			}
 		}
 

--- a/table/render_html_test.go
+++ b/table/render_html_test.go
@@ -2,6 +2,7 @@ package table
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/jedib0t/go-pretty/v6/text"
@@ -90,6 +91,14 @@ func TestTable_RenderHTML_AutoIndex(t *testing.T) {
 		}
 		tw.AppendRow(row)
 	}
+	for rowIdx := 0; rowIdx < 1; rowIdx++ {
+		row := make(Row, 10)
+		for colIdx := 0; colIdx < 10; colIdx++ {
+			row[colIdx] = AutoIndexColumnID(colIdx) + "F"
+		}
+		tw.AppendFooter(row)
+	}
+	tw.SetOutputMirror(os.Stdout)
 	tw.SetAutoIndex(true)
 	tw.SetStyle(StyleLight)
 
@@ -122,6 +131,14 @@ func TestTable_RenderHTML_AutoIndex(t *testing.T) {
     <td>C3</td>
   </tr>
   </tbody>
+  <tfoot>
+  <tr>
+    <td>&nbsp;</td>
+    <td>AF</td>
+    <td>BF</td>
+    <td>CF</td>
+  </tr>
+  </tfoot>
 </table>`
 	assert.Equal(t, expectedOut, tw.RenderHTML())
 }

--- a/table/render_html_test.go
+++ b/table/render_html_test.go
@@ -114,19 +114,19 @@ func TestTable_RenderHTML_AutoIndex(t *testing.T) {
   </thead>
   <tbody>
   <tr>
-    <td>1</td>
+    <td align="right">1</td>
     <td>A1</td>
     <td>B1</td>
     <td>C1</td>
   </tr>
   <tr>
-    <td>2</td>
+    <td align="right">2</td>
     <td>A2</td>
     <td>B2</td>
     <td>C2</td>
   </tr>
   <tr>
-    <td>3</td>
+    <td align="right">3</td>
     <td>A3</td>
     <td>B3</td>
     <td>C3</td>

--- a/table/render_html_test.go
+++ b/table/render_html_test.go
@@ -82,6 +82,7 @@ func TestTable_RenderHTML(t *testing.T) {
 
 	assert.Equal(t, expectedOut, tw.RenderHTML())
 }
+
 func TestTable_RenderHTML_AutoIndex(t *testing.T) {
 	tw := NewWriter()
 	for rowIdx := 0; rowIdx < 3; rowIdx++ {
@@ -92,8 +93,8 @@ func TestTable_RenderHTML_AutoIndex(t *testing.T) {
 		tw.AppendRow(row)
 	}
 	for rowIdx := 0; rowIdx < 1; rowIdx++ {
-		row := make(Row, 10)
-		for colIdx := 0; colIdx < 10; colIdx++ {
+		row := make(Row, 3)
+		for colIdx := 0; colIdx < 3; colIdx++ {
 			row[colIdx] = AutoIndexColumnID(colIdx) + "F"
 		}
 		tw.AppendFooter(row)

--- a/table/render_markdown.go
+++ b/table/render_markdown.go
@@ -48,7 +48,7 @@ func (t *Table) markdownRenderRow(out *strings.Builder, row rowStr, hint renderH
 		if colIdx == 0 && t.autoIndex {
 			out.WriteRune(' ')
 			if hint.isSeparatorRow {
-				out.WriteString("--- ")
+				out.WriteString("---:")
 			} else if hint.isRegularRow() {
 				out.WriteString(fmt.Sprintf("%d ", hint.rowNumber))
 			}

--- a/table/render_markdown_test.go
+++ b/table/render_markdown_test.go
@@ -40,11 +40,18 @@ func TestTable_RenderMarkdown_AutoIndex(t *testing.T) {
 		}
 		tw.AppendRow(row)
 	}
+	for rowIdx := 0; rowIdx < 1; rowIdx++ {
+		row := make(Row, 10)
+		for colIdx := 0; colIdx < 10; colIdx++ {
+			row[colIdx] = AutoIndexColumnID(colIdx) + "F"
+		}
+		tw.AppendFooter(row)
+	}
 	tw.SetAutoIndex(true)
 	tw.SetStyle(StyleLight)
 
 	expectedOut := `| | A | B | C | D | E | F | G | H | I | J |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| ---:| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | 1 | A1 | B1 | C1 | D1 | E1 | F1 | G1 | H1 | I1 | J1 |
 | 2 | A2 | B2 | C2 | D2 | E2 | F2 | G2 | H2 | I2 | J2 |
 | 3 | A3 | B3 | C3 | D3 | E3 | F3 | G3 | H3 | I3 | J3 |
@@ -54,7 +61,8 @@ func TestTable_RenderMarkdown_AutoIndex(t *testing.T) {
 | 7 | A7 | B7 | C7 | D7 | E7 | F7 | G7 | H7 | I7 | J7 |
 | 8 | A8 | B8 | C8 | D8 | E8 | F8 | G8 | H8 | I8 | J8 |
 | 9 | A9 | B9 | C9 | D9 | E9 | F9 | G9 | H9 | I9 | J9 |
-| 10 | A10 | B10 | C10 | D10 | E10 | F10 | G10 | H10 | I10 | J10 |`
+| 10 | A10 | B10 | C10 | D10 | E10 | F10 | G10 | H10 | I10 | J10 |
+| | AF | BF | CF | DF | EF | FF | GF | HF | IF | JF |`
 	assert.Equal(t, expectedOut, tw.RenderMarkdown())
 }
 


### PR DESCRIPTION
PR #109 which fixed issue reported by #108 did not account for turning off auto-index on Footer rows. This change fixes it and ensures that footer rows do not have auto-generated indices.

Fixes #108 again.
