### PR TITLE
Title render references the width of the table

### DIFF
--- a/table/render.go
+++ b/table/render.go
@@ -393,14 +393,18 @@ func (t *Table) renderRowsHeader(out *strings.Builder) {
 
 func (t *Table) renderTitle(out *strings.Builder) {
 	if t.title != "" {
+		rowLength := t.maxRowLength
+		if t.allowedRowLength != 0 && t.allowedRowLength < rowLength {
+			rowLength = t.allowedRowLength
+		}
 		if t.style.Options.DrawBorder {
-			lenBorder := t.maxRowLength - text.RuneCount(t.style.Box.TopLeft+t.style.Box.TopRight)
+			lenBorder := rowLength - text.RuneCount(t.style.Box.TopLeft+t.style.Box.TopRight)
 			out.WriteString(t.style.Box.TopLeft)
 			out.WriteString(text.RepeatAndTrim(t.style.Box.MiddleHorizontal, lenBorder))
 			out.WriteString(t.style.Box.TopRight)
 		}
 
-		lenText := t.maxRowLength - text.RuneCount(t.style.Box.PaddingLeft+t.style.Box.PaddingRight)
+		lenText := rowLength - text.RuneCount(t.style.Box.PaddingLeft+t.style.Box.PaddingRight)
 		if t.style.Options.DrawBorder {
 			lenText -= text.RuneCount(t.style.Box.Left + t.style.Box.Right)
 		}


### PR DESCRIPTION
If allowedLength was set to something shorter than maxRowLength the title was too big for the table
Now it just checks if the allowed length is less and if so uses that
 
## Proposed Changes
  -
  -
  -

Fixes #<insert Issue # here if applicable>.
