### PR TITLE
Title is same width as shortened table now

### DIFF
--- a/table/render.go
+++ b/table/render.go
@@ -393,14 +393,18 @@ func (t *Table) renderRowsHeader(out *strings.Builder) {
 
 func (t *Table) renderTitle(out *strings.Builder) {
 	if t.title != "" {
+		rowLength := t.maxRowLength
+		if t.allowedRowLength != 0 && t.allowedRowLength < rowLength {
+			rowLength = t.allowedRowLength
+		}
 		if t.style.Options.DrawBorder {
-			lenBorder := t.maxRowLength - text.RuneCount(t.style.Box.TopLeft+t.style.Box.TopRight)
+			lenBorder := rowLength - text.RuneCount(t.style.Box.TopLeft+t.style.Box.TopRight)
 			out.WriteString(t.style.Box.TopLeft)
 			out.WriteString(text.RepeatAndTrim(t.style.Box.MiddleHorizontal, lenBorder))
 			out.WriteString(t.style.Box.TopRight)
 		}
 
-		lenText := t.maxRowLength - text.RuneCount(t.style.Box.PaddingLeft+t.style.Box.PaddingRight)
+		lenText := rowLength - text.RuneCount(t.style.Box.PaddingLeft+t.style.Box.PaddingRight)
 		if t.style.Options.DrawBorder {
 			lenText -= text.RuneCount(t.style.Box.Left + t.style.Box.Right)
 		}

--- a/table/render_test.go
+++ b/table/render_test.go
@@ -1242,3 +1242,52 @@ func TestTable_Render_TableWithTransformers(t *testing.T) {
 		}
 	}
 }
+
+func TestTable_Render_SetWidth_Title(t *testing.T) {
+	tw := NewWriter()
+	tw.AppendHeader(testHeader)
+	tw.AppendRows(testRows)
+	tw.AppendFooter(testFooter)
+	tw.SetTitle("Game Of Thrones")
+
+	t.Run("length 20", func(t *testing.T) {
+		tw.SetAllowedRowLength(20)
+
+		expectedOut := []string{
+			"+------------------+",
+			"| Game Of Thrones  |",
+			"+-----+----------- ~",
+			"|   # | FIRST NAME ~",
+			"+-----+----------- ~",
+			"|   1 | Arya       ~",
+			"|  20 | Jon        ~",
+			"| 300 | Tyrion     ~",
+			"+-----+----------- ~",
+			"|     |            ~",
+			"+-----+----------- ~",
+		}
+
+		assert.Equal(t, strings.Join(expectedOut, "\n"), tw.Render())
+	})
+
+	t.Run("length 30", func(t *testing.T) {
+		tw.SetAllowedRowLength(30)
+
+		expectedOut := []string{
+			"+----------------------------+",
+			"| Game Of Thrones            |",
+			"+-----+------------+-------- ~",
+			"|   # | FIRST NAME | LAST NA ~",
+			"+-----+------------+-------- ~",
+			"|   1 | Arya       | Stark   ~",
+			"|  20 | Jon        | Snow    ~",
+			"| 300 | Tyrion     | Lannist ~",
+			"+-----+------------+-------- ~",
+			"|     |            | TOTAL   ~",
+			"+-----+------------+-------- ~",
+		}
+
+		assert.Equal(t, strings.Join(expectedOut, "\n"), tw.Render())
+	})
+
+}


### PR DESCRIPTION
The table can have a maximum width that that title ignored. Now the title will scale with the table
Also added tests because I didn't have them in the first version of this pull request. Sorry
