### PR TITLE
run the CI job every month

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,36 +1,55 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  # Pushes and pulls to all branches
+  push:
+  pull_request:
+
+  # Run on the first day of every month
+  schedule:
+    - cron: "0 0 1 * *"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
+  # Build and test everything
   build:
     runs-on: ubuntu-latest
     steps:
+      # Checkout the code
       - name: Checkout Code
         uses: actions/checkout@v2
 
+      # Set up the GoLang enviroment
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
 
+      # Download all the tools used in the steps that follow
       - name: Set up Tools
         run: |
           go get -u github.com/fzipp/gocyclo/cmd/gocyclo
           go get -u github.com/mattn/goveralls
           go get -u golang.org/x/lint/golint
 
+      # Run all the unit-tests
       - name: Test
         run: |
           make test
 
+      # Run some tests to ensure no race conditions exist
       - name: Test for Race Conditions
         run: make test-race
 
+      # Run the benchmarks to manually ensure no performance degradation
       - name: Benchmark
         run: make bench
 
+      # Upload all the unit-test coverage reports to Coveralls
       - name: Upload Coverage Report
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
         run: goveralls -service=travis-pro -coverprofile=.coverprofile
+


### PR DESCRIPTION
Update the CI workflow:
- to be triggered automatically on the first day of every month
- to be manually runnable from the Actions tab on demand