### PR TITLE
progress: fix incorrect mutex usages

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -2,7 +2,6 @@ package progress
 
 import (
 	"io"
-	"math"
 	"os"
 	"sync"
 	"time"
@@ -65,11 +64,6 @@ const (
 // to a queue, which gets picked up by the Render logic in the next rendering
 // cycle.
 func (p *Progress) AppendTracker(t *Tracker) {
-	t.mutex.Lock()
-	if t.Total < 0 {
-		t.Total = math.MaxInt64
-	}
-	t.mutex.Unlock()
 	t.start()
 
 	p.overallTrackerMutex.Lock()

--- a/progress/tracker.go
+++ b/progress/tracker.go
@@ -141,8 +141,8 @@ func (t *Tracker) SetValue(value int64) {
 
 // Value returns the current value of the tracker.
 func (t *Tracker) Value() int64 {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
 	return t.value
 }
 


### PR DESCRIPTION
- tracker.mutexPrv is useless since it only protects writes. Removed it.
- Remove usages of tracker.mutex outside of the tracker object, ensures usage is more obviously correct
- Fix race condition that occurred when generating the tracker string
- tracker.Value is only reading, so use RLock

I ran the demo with the race detector several times and wasn't able to duplicate the race found in https://github.com/jedib0t/go-pretty/pull/153/checks?check_run_id=2266140256, but it seems pretty obvious that this is the culprit.