### PR TITLE
progress: Tracker.UpdateMessage(...) to safely update message

### DIFF
--- a/progress/render_test.go
+++ b/progress/render_test.go
@@ -74,10 +74,7 @@ func trackSomethingErrored(pw Writer, tracker *Tracker) {
 			if tracker.value+incrementPerCycle > total {
 				tracker.MarkAsErrored()
 			} else {
-				tracker.Increment(incrementPerCycle)
-			}
-			if tracker.Value() >= total {
-				tracker.MarkAsErrored()
+				tracker.IncrementWithError(incrementPerCycle)
 			}
 		}
 	}

--- a/progress/tracker_sort.go
+++ b/progress/tracker_sort.go
@@ -52,13 +52,13 @@ type sortByMessage []*Tracker
 
 func (sb sortByMessage) Len() int           { return len(sb) }
 func (sb sortByMessage) Swap(i, j int)      { sb[i], sb[j] = sb[j], sb[i] }
-func (sb sortByMessage) Less(i, j int) bool { return sb[i].Message < sb[j].Message }
+func (sb sortByMessage) Less(i, j int) bool { return sb[i].message() < sb[j].message() }
 
 type sortByMessageDsc []*Tracker
 
 func (sb sortByMessageDsc) Len() int           { return len(sb) }
 func (sb sortByMessageDsc) Swap(i, j int)      { sb[i], sb[j] = sb[j], sb[i] }
-func (sb sortByMessageDsc) Less(i, j int) bool { return sb[i].Message > sb[j].Message }
+func (sb sortByMessageDsc) Less(i, j int) bool { return sb[i].message() > sb[j].message() }
 
 type sortByPercent []*Tracker
 

--- a/progress/tracker_test.go
+++ b/progress/tracker_test.go
@@ -53,6 +53,7 @@ func TestTracker_IncrementWithError(t *testing.T) {
 	tracker := Tracker{Total: 100}
 	assert.Equal(t, int64(0), tracker.value)
 	assert.Equal(t, int64(100), tracker.Total)
+	assert.False(t, tracker.IsErrored())
 
 	tracker.IncrementWithError(10)
 	assert.Equal(t, int64(10), tracker.value)
@@ -174,4 +175,12 @@ func TestTracker_Value(t *testing.T) {
 	tracker.SetValue(5)
 	assert.Equal(t, int64(5), tracker.value)
 	assert.Equal(t, int64(5), tracker.Value())
+}
+
+func TestTracker_UpdateMessage(t *testing.T) {
+	tracker := Tracker{Message: "foo"}
+	assert.Equal(t, "foo", tracker.message())
+
+	tracker.UpdateMessage("bar")
+	assert.Equal(t, "bar", tracker.message())
 }


### PR DESCRIPTION
## Proposed Changes

Introduce Tracker.UpdateMessage() to provide a safe way of updating the Message string in the middle of progress.

Change is made in a way to not warrant a major version bump.

Partially addresses the root-cause for #159.
