### PR TITLE
progress: use UpdateMessage in the demo

### DIFF
--- a/cmd/demo-progress/demo.go
+++ b/cmd/demo-progress/demo.go
@@ -59,7 +59,6 @@ func trackSomething(pw progress.Writer, idx int64, updateMessage bool) {
 	pw.AppendTracker(&tracker)
 
 	ticker := time.Tick(time.Millisecond * 500)
-	updateRandomizer := rand.New(rand.NewSource(13))
 	updateTicker := time.Tick(time.Millisecond * 250)
 	for !tracker.IsDone() {
 		select {
@@ -72,7 +71,7 @@ func trackSomething(pw progress.Writer, idx int64, updateMessage bool) {
 			}
 		case <-updateTicker:
 			if updateMessage {
-				rndIdx := updateRandomizer.Intn(len(messageColors))
+				rndIdx := rand.Intn(len(messageColors))
 				if rndIdx == len(messageColors) {
 					rndIdx--
 				}

--- a/cmd/demo-progress/demo.go
+++ b/cmd/demo-progress/demo.go
@@ -7,15 +7,26 @@ import (
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/progress"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 var (
 	autoStop    = flag.Bool("auto-stop", false, "Auto-stop rendering?")
 	randomFail  = flag.Bool("rnd-fail", false, "Enable random failures")
 	numTrackers = flag.Int("num-trackers", 13, "Number of Trackers")
+
+	messageColors = []text.Color{
+		text.FgRed,
+		text.FgGreen,
+		text.FgYellow,
+		text.FgBlue,
+		text.FgMagenta,
+		text.FgCyan,
+		text.FgWhite,
+	}
 )
 
-func trackSomething(pw progress.Writer, idx int64) {
+func trackSomething(pw progress.Writer, idx int64, updateMessage bool) {
 	total := idx * idx * idx * 250
 	incrementPerCycle := idx * int64(*numTrackers) * 250
 
@@ -47,15 +58,25 @@ func trackSomething(pw progress.Writer, idx int64) {
 
 	pw.AppendTracker(&tracker)
 
-	c := time.Tick(time.Millisecond * 500)
+	ticker := time.Tick(time.Millisecond * 500)
+	updateRandomizer := rand.New(rand.NewSource(13))
+	updateTicker := time.Tick(time.Millisecond * 250)
 	for !tracker.IsDone() {
 		select {
-		case <-c:
+		case <-ticker:
 			tracker.Increment(incrementPerCycle)
 			if idx == int64(*numTrackers) && tracker.Value() >= total {
 				tracker.MarkAsDone()
 			} else if *randomFail && rand.Float64() < 0.1 {
 				tracker.MarkAsErrored()
+			}
+		case <-updateTicker:
+			if updateMessage {
+				rndIdx := updateRandomizer.Intn(len(messageColors))
+				if rndIdx == len(messageColors) {
+					rndIdx--
+				}
+				tracker.UpdateMessage(messageColors[rndIdx].Sprint(message))
 			}
 		}
 	}
@@ -90,7 +111,7 @@ func main() {
 	// features available; do this in async too like a client might do (for ex.
 	// when downloading a bunch of files in parallel)
 	for idx := int64(1); idx <= int64(*numTrackers); idx++ {
-		go trackSomething(pw, idx)
+		go trackSomething(pw, idx, idx == int64(*numTrackers))
 
 		// in auto-stop mode, the Render logic terminates the moment it detects
 		// zero active trackers; but in a manual-stop mode, it keeps waiting and


### PR DESCRIPTION
In the progress-bar demo, update the message of a single tracker continuously during the course of execution using UpdateMessage() to show that `make test-race` does not fail.