### PR TITLE
fix: outdated docs and example on styling table

### DIFF
--- a/table/README.md
+++ b/table/README.md
@@ -161,8 +161,7 @@ You can also roll your own style:
             UnfinishedRow:    " ~~~",
         },
         Color: table.ColorOptions{
-            AutoIndexColumn: nil,
-            FirstColumn:     nil,
+            IndexColumn:     text.Colors{text.BgCyan, text.FgBlack},
             Footer:          text.Colors{text.BgCyan, text.FgBlack},
             Header:          text.Colors{text.BgHiCyan, text.FgBlack},
             Row:             text.Colors{text.BgHiWhite, text.FgBlack},
@@ -189,6 +188,10 @@ Or you can use one of the ready-to-use Styles, and just make a few tweaks:
     t.Style().Color.Header = text.Colors{text.BgHiCyan, text.FgBlack}
     t.Style().Format.Footer = text.FormatLower
     t.Style().Options.DrawBorder = false
+    
+    // Color 1st column only
+    t.SetIndexColumn(1)
+    t.Style().Color.IndexColumn = text.Colors{text.BgHiCyan, text.FgBlack} 
 ```
 
 ## Auto-Merge


### PR DESCRIPTION
## Proposed Changes
  - added an example to style 1st columns using the new style `IndexColumn` approach.
  - update docs as per changes in https://github.com/jedib0t/go-pretty/commit/e026101c083d12bd3bfc6de987b2976705939712

