### PR TITLE
progress: always perform a final render before exiting the render loop

### DIFF
--- a/progress/render.go
+++ b/progress/render.go
@@ -29,6 +29,12 @@ func (p *Progress) Render() {
 					lastRenderLength = p.renderTrackers(lastRenderLength)
 				}
 			case <-p.done:
+				// always render the current state before finishing render in case
+				// it hasn't been shown yet
+				if p.LengthActive() > 0 {
+					lastRenderLength = p.renderTrackers(lastRenderLength)
+				}
+
 				p.renderInProgressMutex.Lock()
 				p.renderInProgress = false
 				p.renderInProgressMutex.Unlock()


### PR DESCRIPTION
I expect that when I call Stop() that whatever the current state of any trackers will have been written to the output. However, there's currently no guarantee that the current output was written, even if Stop is called after all of my tracker updates on the same goroutine. Here's a silly example that demonstrates the point:

```
package main

import (
	"time"

	"github.com/jedib0t/go-pretty/v6/progress"
)

func main() {

	var prog progress.Progress
	prog.Style().Colors = progress.StyleColorsExample
	prog.Style().Options.PercentFormat = "%4.1f%%"
	go prog.Render()

	t := progress.Tracker{
		Message: "Interesting thing",
		Total:   30,
	}

	prog.AppendTracker(&t)

	for i := 0; i < 30; i++ {
		t.Increment(1)
		time.Sleep(1 * time.Millisecond)
	}

	t.MarkAsDone()

	prog.Stop()
	for {
		if !prog.IsRenderInProgress() {
			break
		}
		time.Sleep(50 * time.Millisecond)
	}

}
```

If you run this without this PR applied, there will never be output shown because the render never gets a chance to run.
