### PR TITLE
Added support for notation position of progress bar tracker value

### DIFF
--- a/progress/units.go
+++ b/progress/units.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 )
 
+// UnitsNotationPosition determines units position relative of tracker value
+// Defaults is UnitsNotationPositionBefore
 type UnitsNotationPosition int
 
+// Supported unit positions relative to tracker value
 const (
 	UnitsNotationPositionBefore UnitsNotationPosition = iota
 	UnitsNotationPositionAfter

--- a/progress/units.go
+++ b/progress/units.go
@@ -4,10 +4,18 @@ import (
 	"fmt"
 )
 
+type UnitsNotationPosition int
+
+const (
+	UnitsNotationPositionBefore UnitsNotationPosition = iota
+	UnitsNotationPositionAfter
+)
+
 // Units defines the "type" of the value being tracked by the Tracker.
 type Units struct {
 	Notation  string
 	Formatter func(value int64) string
+	NotationPosition UnitsNotationPosition
 }
 
 var (
@@ -52,10 +60,23 @@ var (
 
 // Sprint prints the value as defined by the Units.
 func (tu Units) Sprint(value int64) string {
-	if tu.Formatter == nil {
-		return tu.Notation + FormatNumber(value)
+	formatter := tu.Formatter
+	if formatter == nil {
+		formatter = FormatNumber
 	}
-	return tu.Notation + tu.Formatter(value)
+
+	formattedValue := formatter(value)
+
+	switch tu.NotationPosition {
+	case UnitsNotationPositionBefore:
+		return tu.Notation + formattedValue
+
+	case UnitsNotationPositionAfter:
+		return formattedValue + tu.Notation
+
+	default:
+		return tu.Notation + formattedValue
+	}
 }
 
 // FormatBytes formats the given value as a "Byte".

--- a/progress/units_test.go
+++ b/progress/units_test.go
@@ -36,3 +36,11 @@ func TestUnits_Sprint(t *testing.T) {
 	customUnits := Units{Notation: "#"}
 	assert.Equal(t, "#1.50K", customUnits.Sprint(1500))
 }
+
+func TestUnits_NotationPosition(t *testing.T) {
+	afterUnits := Units{Notation: " ₽", NotationPosition: UnitsNotationPositionAfter}
+	assert.Equal(t, "1.50K ₽", afterUnits.Sprint(1500))
+
+	unknownNotationPosition := Units{Notation: "* ", NotationPosition: UnitsNotationPosition(999)}
+	assert.Equal(t, "* 1.50K", unknownNotationPosition.Sprint(1500))
+}


### PR DESCRIPTION
## Proposed Changes
  - Added `NotationPosition` field to `progress.Units` struct
  - Added `UnitsNotationPositionBefore` (as default) and `UnitsNotationPositionAfter` constants
  - Changes in `progress.Units.Sprint` method
