### PR TITLE
progress: refactor visibility options (Show*); fixes #196

### DIFF
--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -165,44 +165,52 @@ func TestProgress_SetUpdateFrequency(t *testing.T) {
 	assert.Equal(t, time.Duration(time.Second), p.updateFrequency)
 }
 
+func TestProgress_ShowETA(t *testing.T) {
+	p := Progress{}
+	assert.False(t, p.Style().Visibility.ETA)
+
+	p.ShowETA(true)
+	assert.True(t, p.Style().Visibility.ETA)
+}
+
 func TestProgress_ShowOverallTracker(t *testing.T) {
 	p := Progress{}
-	assert.False(t, p.showOverallTracker)
+	assert.False(t, p.Style().Visibility.TrackerOverall)
 
 	p.ShowOverallTracker(true)
-	assert.True(t, p.showOverallTracker)
+	assert.True(t, p.Style().Visibility.TrackerOverall)
 }
 
 func TestProgress_ShowPercentage(t *testing.T) {
 	p := Progress{}
-	assert.False(t, p.hidePercentage)
+	assert.True(t, p.Style().Visibility.Percentage)
 
 	p.ShowPercentage(false)
-	assert.True(t, p.hidePercentage)
+	assert.False(t, p.Style().Visibility.Percentage)
 }
 
 func TestProgress_ShowTime(t *testing.T) {
 	p := Progress{}
-	assert.False(t, p.hideTime)
+	assert.True(t, p.Style().Visibility.Time)
 
 	p.ShowTime(false)
-	assert.True(t, p.hideTime)
+	assert.False(t, p.Style().Visibility.Time)
 }
 
 func TestProgress_ShowTracker(t *testing.T) {
 	p := Progress{}
-	assert.False(t, p.hideTracker)
+	assert.True(t, p.Style().Visibility.Tracker)
 
 	p.ShowTracker(false)
-	assert.True(t, p.hideTracker)
+	assert.False(t, p.Style().Visibility.Tracker)
 }
 
 func TestProgress_ShowValue(t *testing.T) {
 	p := Progress{}
-	assert.False(t, p.hideValue)
+	assert.True(t, p.Style().Visibility.Value)
 
 	p.ShowValue(false)
-	assert.True(t, p.hideValue)
+	assert.False(t, p.Style().Visibility.Value)
 }
 
 func TestProgress_Stop(t *testing.T) {

--- a/progress/style.go
+++ b/progress/style.go
@@ -8,43 +8,48 @@ import (
 
 // Style declares how to render the Progress/Trackers.
 type Style struct {
-	Name    string       // name of the Style
-	Chars   StyleChars   // characters to use on the progress bar
-	Colors  StyleColors  // colors to use on the progress bar
-	Options StyleOptions // misc. options for the progress bar
+	Name       string          // name of the Style
+	Chars      StyleChars      // characters to use on the progress bar
+	Colors     StyleColors     // colors to use on the progress bar
+	Options    StyleOptions    // misc. options for the progress bar
+	Visibility StyleVisibility // show/hide components of the progress bar(s)
 }
 
 var (
 	// StyleDefault uses ASCII text to render the Trackers.
 	StyleDefault = Style{
-		Name:    "StyleDefault",
-		Chars:   StyleCharsDefault,
-		Colors:  StyleColorsDefault,
-		Options: StyleOptionsDefault,
+		Name:       "StyleDefault",
+		Chars:      StyleCharsDefault,
+		Colors:     StyleColorsDefault,
+		Options:    StyleOptionsDefault,
+		Visibility: StyleVisibilityDefault,
 	}
 
 	// StyleBlocks uses UNICODE Block Drawing characters to render the Trackers.
 	StyleBlocks = Style{
-		Name:    "StyleBlocks",
-		Chars:   StyleCharsBlocks,
-		Colors:  StyleColorsDefault,
-		Options: StyleOptionsDefault,
+		Name:       "StyleBlocks",
+		Chars:      StyleCharsBlocks,
+		Colors:     StyleColorsDefault,
+		Options:    StyleOptionsDefault,
+		Visibility: StyleVisibilityDefault,
 	}
 
 	// StyleCircle uses UNICODE Circle runes to render the Trackers.
 	StyleCircle = Style{
-		Name:    "StyleCircle",
-		Chars:   StyleCharsCircle,
-		Colors:  StyleColorsDefault,
-		Options: StyleOptionsDefault,
+		Name:       "StyleCircle",
+		Chars:      StyleCharsCircle,
+		Colors:     StyleColorsDefault,
+		Options:    StyleOptionsDefault,
+		Visibility: StyleVisibilityDefault,
 	}
 
 	// StyleRhombus uses UNICODE Rhombus runes to render the Trackers.
 	StyleRhombus = Style{
-		Name:    "StyleRhombus",
-		Chars:   StyleCharsRhombus,
-		Colors:  StyleColorsDefault,
-		Options: StyleOptionsDefault,
+		Name:       "StyleRhombus",
+		Chars:      StyleCharsRhombus,
+		Colors:     StyleColorsDefault,
+		Options:    StyleOptionsDefault,
+		Visibility: StyleVisibilityDefault,
 	}
 )
 
@@ -170,5 +175,29 @@ var (
 		TimeDonePrecision:       time.Millisecond,
 		TimeInProgressPrecision: time.Microsecond,
 		TimeOverallPrecision:    time.Second,
+	}
+)
+
+// StyleVisibility controls what gets shown and what gets hidden.
+type StyleVisibility struct {
+	ETA            bool // ETA for each tracker
+	ETAOverall     bool // ETA for the overall tracker
+	Percentage     bool // tracker progress percentage value
+	Time           bool // tracker time taken
+	Tracker        bool // tracker ([===========-----------])
+	TrackerOverall bool // overall tracker
+	Value          bool // tracker value
+}
+
+var (
+	// StyleVisibilityDefault defines sane defaults for the Visibility.
+	StyleVisibilityDefault = StyleVisibility{
+		ETA:            false,
+		ETAOverall:     true,
+		Percentage:     true,
+		Time:           true,
+		Tracker:        true,
+		TrackerOverall: false,
+		Value:          true,
 	}
 )

--- a/progress/writer.go
+++ b/progress/writer.go
@@ -24,11 +24,17 @@ type Writer interface {
 	SetStyle(style Style)
 	SetTrackerLength(length int)
 	SetTrackerPosition(position Position)
+	// Deprecated: in favor of Style().Visibility.ETA
 	ShowETA(show bool)
+	// Deprecated: in favor of Style().Visibility.TrackerOverall
 	ShowOverallTracker(show bool)
+	// Deprecated: in favor of Style().Visibility.Percentage
 	ShowPercentage(show bool)
+	// Deprecated: in favor of Style().Visibility.Time
 	ShowTime(show bool)
+	// Deprecated: in favor of Style().Visibility.Tracker
 	ShowTracker(show bool)
+	// Deprecated: in favor of Style().Visibility.Value
 	ShowValue(show bool)
 	SetUpdateFrequency(frequency time.Duration)
 	Stop()


### PR DESCRIPTION
## Proposed Changes
  - Deprecate all the `Show*` interfaces in `progress.Progres`s and `progress.Writer`
  - Introduce `progress.Style.Visibility` with same defaults as before
  - Introduce `progress.Style.Visibility.ETAOverall` as a new option for addressing bug #196 

