### PR TITLE
list: add unindent all function

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -121,9 +121,7 @@ func (l *List) UnIndent() {
 }
 
 func (l *List) UnIndentAll() {
-	for l.level > 0 {
-		l.level--
-	}
+	l.level = 0
 }
 
 func (l *List) initForRender() {

--- a/list/list.go
+++ b/list/list.go
@@ -120,6 +120,12 @@ func (l *List) UnIndent() {
 	}
 }
 
+func (l *List) UnIndentAll() {
+	for l.level > 0 {
+		l.level--
+	}
+}
+
 func (l *List) initForRender() {
 	// pick a default style
 	l.Style()

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -149,3 +149,14 @@ func TestList_UnIndent(t *testing.T) {
 	list.UnIndent()
 	assert.Equal(t, 0, list.level)
 }
+
+func TestList_UnIndentAll(t *testing.T) {
+	list := List{level: 3}
+
+	list.UnIndentAll()
+	assert.Equal(t, 0, list.level)
+
+	// Ensure level is still 0 after 2 consecutive calls
+	list.UnIndentAll()
+	assert.Equal(t, 0, list.level)
+}

--- a/list/render_test.go
+++ b/list/render_test.go
@@ -289,3 +289,47 @@ func TestList_Render_Styles(t *testing.T) {
 		fmt.Println(mismatch)
 	}
 }
+
+func TestList_Render_UnindentAll(t *testing.T) {
+	lw := NewWriter()
+	lw.AppendItem(testItem1)
+	lw.Indent()
+	lw.AppendItems(testItems2)
+	lw.Indent()
+	lw.AppendItems(testItems3)
+	lw.UnIndentAll()
+	lw.AppendItem(testItem4)
+	lw.Indent()
+	lw.AppendItem(testItem5)
+	lw.UnIndentAll()
+	lw.AppendItem("The Mandalorian")
+	lw.Indent()
+	lw.AppendItem("This")
+	lw.Indent()
+	lw.AppendItem("Is")
+	lw.Indent()
+	lw.AppendItem("The")
+	lw.Indent()
+	lw.AppendItem("Way")
+	lw.Indent()
+	lw.UnIndentAll()
+	lw.AppendItem("Right?")
+
+	expectedOut := `* Game Of Thrones
+  * Winter
+  * Is
+  * Coming
+    * This
+    * Is
+    * Known
+* The Dark Tower
+  * The Gunslinger
+* The Mandalorian
+  * This
+    * Is
+      * The
+        * Way
+* Right?`
+	assert.Equal(t, expectedOut, lw.Render())
+
+}

--- a/list/writer.go
+++ b/list/writer.go
@@ -17,6 +17,7 @@ type Writer interface {
 	SetStyle(style Style)
 	Style() *Style
 	UnIndent()
+	UnIndentAll()
 }
 
 // NewWriter initializes and returns a Writer.


### PR DESCRIPTION
## Proposed Changes

This adds a function to unindent the list item to the base of the list, regardless of the indentation level its in. 

I wrote this up after needing it in my personal projects. WDYT? 

