### PR TITLE
table: do not colorize border using row-painter (fixes #221)

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -422,7 +422,7 @@ func (t *Table) getBorderRight(hint renderHint) string {
 }
 
 func (t *Table) getColumnColors(colIdx int, hint renderHint) text.Colors {
-	if t.rowPainter != nil && hint.isRegularRow() && !t.isIndexColumn(colIdx, hint) {
+	if t.rowPainter != nil && hint.isRegularNonSeparatorRow() && !t.isIndexColumn(colIdx, hint) {
 		colors := t.rowsColors[hint.rowNumber-1]
 		if colors != nil {
 			return colors
@@ -991,6 +991,10 @@ type renderHint struct {
 
 func (h *renderHint) isRegularRow() bool {
 	return !h.isHeaderRow && !h.isFooterRow
+}
+
+func (h *renderHint) isRegularNonSeparatorRow() bool {
+	return !h.isHeaderRow && !h.isFooterRow && !h.isSeparatorRow
 }
 
 func (h *renderHint) isHeaderOrFooterSeparator() bool {


### PR DESCRIPTION
The colors for the separator row was using the output of rowPainter incorrectly. This change fixes it.
