### PR TITLE
progress: add pin message

### DIFF
--- a/cmd/demo-progress/demo.go
+++ b/cmd/demo-progress/demo.go
@@ -88,7 +88,8 @@ func trackSomething(pw progress.Writer, idx int64, updateMessage bool) {
 			} else if *flagRandomFail && rand.Float64() < 0.1 {
 				tracker.MarkAsErrored()
 			}
-			pw.SetPinMessage(fmt.Sprintf("Pin Time: %s", time.Now().Format(time.RFC3339)))
+			t := time.Now().Format(time.RFC3339)
+			pw.SetPinMessage(fmt.Sprintf("Current Time: %s", t), fmt.Sprintf("CURRENT TIME: %s", t))
 		case <-updateTicker:
 			if updateMessage {
 				rndIdx := rand.Intn(len(messageColors))

--- a/cmd/demo-progress/demo.go
+++ b/cmd/demo-progress/demo.go
@@ -21,6 +21,7 @@ var (
 	flagNumTrackers        = flag.Int("num-trackers", 13, "Number of Trackers")
 	flagShowSpeed          = flag.Bool("show-speed", false, "Show the tracker speed?")
 	flagShowSpeedOverall   = flag.Bool("show-speed-overall", false, "Show the overall tracker speed?")
+	flagShowPin            = flag.Bool("show-pin", false, "Show the pin message?")
 	flagRandomFail         = flag.Bool("rnd-fail", false, "Introduce random failures in tracking")
 	flagRandomLogs         = flag.Bool("rnd-logs", false, "Output random logs in the middle of tracking")
 
@@ -87,6 +88,7 @@ func trackSomething(pw progress.Writer, idx int64, updateMessage bool) {
 			} else if *flagRandomFail && rand.Float64() < 0.1 {
 				tracker.MarkAsErrored()
 			}
+			pw.SetPinMessage(fmt.Sprintf("Pin Time: %s", time.Now().Format(time.RFC3339)))
 		case <-updateTicker:
 			if updateMessage {
 				rndIdx := rand.Intn(len(messageColors))
@@ -123,6 +125,7 @@ func main() {
 	pw.Style().Visibility.Time = !*flagHideTime
 	pw.Style().Visibility.TrackerOverall = !*flagHideOverallTracker
 	pw.Style().Visibility.Value = !*flagHideValue
+	pw.Style().Visibility.Pin = *flagShowPin
 
 	// call Render() in async mode; yes we don't have any trackers at the moment
 	go pw.Render()

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -28,7 +29,7 @@ type Progress struct {
 	lengthProgress        int
 	lengthProgressOverall int
 	outputWriter          io.Writer
-	pinMessage            string
+	pinMessage            []string // split by '\n'
 	pinMessageMutex       sync.RWMutex
 	logsToRender          []string
 	logsToRenderMutex     sync.RWMutex
@@ -151,7 +152,7 @@ func (p *Progress) PinMessage() string {
 	p.pinMessageMutex.RLock()
 	defer p.pinMessageMutex.RUnlock()
 
-	return p.pinMessage
+	return strings.Join(p.pinMessage, "\n")
 }
 
 // Log appends a log to display above the active progress bars during the next
@@ -222,12 +223,12 @@ func (p *Progress) SetUpdateFrequency(frequency time.Duration) {
 	p.updateFrequency = frequency
 }
 
-// SetPinMessage sets the pin message of the progress bar. It can be modified in progress.
-func (p *Progress) SetPinMessage(pin string) {
+// SetPinMessage sets the pin message of the progress bar. It can be modified in progress. messages will be displayed per line
+func (p *Progress) SetPinMessage(messages ...string) {
 	p.pinMessageMutex.Lock()
 	defer p.pinMessageMutex.Unlock()
 
-	p.pinMessage = pin
+	p.pinMessage = messages
 }
 
 // ShowETA toggles showing the ETA for all individual trackers.

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -28,6 +28,8 @@ type Progress struct {
 	lengthProgress        int
 	lengthProgressOverall int
 	outputWriter          io.Writer
+	pinMessage            string
+	pinMessageMutex       sync.RWMutex
 	logsToRender          []string
 	logsToRenderMutex     sync.RWMutex
 	messageWidth          int
@@ -144,6 +146,14 @@ func (p *Progress) LengthInQueue() int {
 	return out
 }
 
+// PinMessage returns the current pinned message.
+func (p *Progress) PinMessage() string {
+	p.pinMessageMutex.RLock()
+	defer p.pinMessageMutex.RUnlock()
+
+	return p.pinMessage
+}
+
 // Log appends a log to display above the active progress bars during the next
 // refresh.
 func (p *Progress) Log(msg string, a ...interface{}) {
@@ -210,6 +220,14 @@ func (p *Progress) SetTrackerPosition(position Position) {
 // sane value would be 250ms.
 func (p *Progress) SetUpdateFrequency(frequency time.Duration) {
 	p.updateFrequency = frequency
+}
+
+// SetPinMessage sets the pin message of the progress bar. It can be modified in progress.
+func (p *Progress) SetPinMessage(pin string) {
+	p.pinMessageMutex.Lock()
+	defer p.pinMessageMutex.Unlock()
+
+	p.pinMessage = pin
 }
 
 // ShowETA toggles showing the ETA for all individual trackers.

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -233,16 +233,16 @@ func TestProgress_Style(t *testing.T) {
 
 func TestProgress_SetPinMessage(t *testing.T) {
 	p := Progress{}
-	assert.Equal(t, "", p.pinMessage)
+	assert.Nil(t, p.pinMessage)
 
-	p.SetPinMessage("testing pin message")
-	assert.Equal(t, "testing pin message", p.pinMessage)
+	p.SetPinMessage("pin1", "pin2")
+	assert.Equal(t, []string{"pin1", "pin2"}, p.pinMessage)
 }
 
 func TestProgress_PinMessage(t *testing.T) {
 	p := Progress{}
-	assert.Equal(t, "", p.pinMessage)
+	assert.Nil(t, p.pinMessage)
 
-	p.pinMessage = "testing pin message"
-	assert.Equal(t, "testing pin message", p.PinMessage())
+	p.pinMessage = []string{"pin1", "pin2"}
+	assert.Equal(t, "pin1\npin2", p.PinMessage())
 }

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -230,3 +230,19 @@ func TestProgress_Style(t *testing.T) {
 	assert.NotNil(t, p.Style())
 	assert.Equal(t, StyleDefault.Name, p.Style().Name)
 }
+
+func TestProgress_SetPinMessage(t *testing.T) {
+	p := Progress{}
+	assert.Equal(t, "", p.pinMessage)
+
+	p.SetPinMessage("testing pin message")
+	assert.Equal(t, "testing pin message", p.pinMessage)
+}
+
+func TestProgress_PinMessage(t *testing.T) {
+	p := Progress{}
+	assert.Equal(t, "", p.pinMessage)
+
+	p.pinMessage = "testing pin message"
+	assert.Equal(t, "testing pin message", p.PinMessage())
+}

--- a/progress/render.go
+++ b/progress/render.go
@@ -158,6 +158,9 @@ func (p *Progress) moveCursorToTheTop(out *strings.Builder) {
 	if p.style.Visibility.TrackerOverall && p.overallTracker != nil && !p.overallTracker.IsDone() {
 		numLinesToMoveUp++
 	}
+	if p.style.Visibility.Pin {
+		numLinesToMoveUp++
+	}
 	if numLinesToMoveUp > 0 {
 		out.WriteString(text.CursorUp.Sprintn(numLinesToMoveUp))
 	}
@@ -287,6 +290,14 @@ func (p *Progress) renderTrackers(lastRenderLength int) int {
 	return out.Len()
 }
 
+func (p *Progress) renderPin(out *strings.Builder) {
+	p.pinMessageMutex.RLock()
+	out.WriteString(text.EraseLine.Sprint())
+	out.WriteString(p.Style().Colors.Pin.Sprint(p.pinMessage))
+	out.WriteRune('\n')
+	p.pinMessageMutex.RUnlock()
+}
+
 func (p *Progress) renderTrackersDoneAndActive(out *strings.Builder) {
 	// find the currently "active" and "done" trackers
 	trackersActive, trackersDone := p.extractDoneAndActiveTrackers()
@@ -308,6 +319,11 @@ func (p *Progress) renderTrackersDoneAndActive(out *strings.Builder) {
 	}
 	p.logsToRender = nil
 	p.logsToRenderMutex.Unlock()
+
+	// render pin message
+	if p.style.Visibility.Pin {
+		p.renderPin(out)
+	}
 
 	// sort and render the active trackers
 	for _, tracker := range trackersActive {

--- a/progress/render.go
+++ b/progress/render.go
@@ -159,7 +159,7 @@ func (p *Progress) moveCursorToTheTop(out *strings.Builder) {
 		numLinesToMoveUp++
 	}
 	if p.style.Visibility.Pin {
-		numLinesToMoveUp++
+		numLinesToMoveUp += len(p.pinMessage)
 	}
 	if numLinesToMoveUp > 0 {
 		out.WriteString(text.CursorUp.Sprintn(numLinesToMoveUp))
@@ -292,9 +292,11 @@ func (p *Progress) renderTrackers(lastRenderLength int) int {
 
 func (p *Progress) renderPin(out *strings.Builder) {
 	p.pinMessageMutex.RLock()
-	out.WriteString(text.EraseLine.Sprint())
-	out.WriteString(p.Style().Colors.Pin.Sprint(p.pinMessage))
-	out.WriteRune('\n')
+	for _, pin := range p.pinMessage {
+		out.WriteString(text.EraseLine.Sprint())
+		out.WriteString(p.Style().Colors.Pin.Sprint(pin))
+		out.WriteRune('\n')
+	}
 	p.pinMessageMutex.RUnlock()
 }
 

--- a/progress/render_test.go
+++ b/progress/render_test.go
@@ -815,3 +815,35 @@ func TestProgress_RenderSomeTrackers_WithOverallTracker_WithSpeedOverall_Without
 	}
 	showOutputOnFailure(t, out)
 }
+
+func TestProgress_RenderSomeTrackers_WithPinMessage(t *testing.T) {
+	renderOutput := outputWriter{}
+
+	pw := generateWriter()
+	pw.SetMessageWidth(5)
+	pw.SetOutputWriter(&renderOutput)
+	pw.SetTrackerPosition(PositionRight)
+	pw.Style().Visibility.Pin = true
+	pw.SetPinMessage("PIN")
+	go trackSomething(pw, &Tracker{Message: "Calculating Total   # 1\r", Total: 1000, Units: UnitsDefault})
+	go trackSomething(pw, &Tracker{Message: "Downloading File\t# 2", Total: 1000, Units: UnitsBytes})
+	go trackSomething(pw, &Tracker{Message: "Transferring Amount # 3", Total: 1000, Units: UnitsCurrencyDollar})
+	renderAndWait(pw, false)
+
+	expectedOutPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`\x1b\[KPIN`),
+		regexp.MustCompile(`\x1b\[KCalc~ \.\.\. \d+\.\d+% \[[#.]{23}] \[\d+ in [\d.]+ms]`),
+		regexp.MustCompile(`\x1b\[KDown~ \.\.\. \d+\.\d+% \[[#.]{23}] \[\d+B in [\d.]+ms]`),
+		regexp.MustCompile(`\x1b\[KTran~ \.\.\. \d+\.\d+% \[[#.]{23}] \[\$\d+ in [\d.]+ms]`),
+		regexp.MustCompile(`\x1b\[KCalc~ \.\.\. done! \[\d+\.\d+K in [\d.]+ms]`),
+		regexp.MustCompile(`\x1b\[KDown~ \.\.\. done! \[\d+\.\d+KB in [\d.]+ms]`),
+		regexp.MustCompile(`\x1b\[KTran~ \.\.\. done! \[\$\d+\.\d+K in [\d.]+ms]`),
+	}
+	out := renderOutput.String()
+	for _, expectedOutPattern := range expectedOutPatterns {
+		if !expectedOutPattern.MatchString(out) {
+			assert.Fail(t, "Failed to find a pattern in the Output.", expectedOutPattern.String())
+		}
+	}
+	showOutputOnFailure(t, out)
+}

--- a/progress/render_test.go
+++ b/progress/render_test.go
@@ -816,7 +816,7 @@ func TestProgress_RenderSomeTrackers_WithOverallTracker_WithSpeedOverall_Without
 	showOutputOnFailure(t, out)
 }
 
-func TestProgress_RenderSomeTrackers_WithPinMessage(t *testing.T) {
+func TestProgress_RenderSomeTrackers_WithPinMessage_OneLine(t *testing.T) {
 	renderOutput := outputWriter{}
 
 	pw := generateWriter()
@@ -832,6 +832,39 @@ func TestProgress_RenderSomeTrackers_WithPinMessage(t *testing.T) {
 
 	expectedOutPatterns := []*regexp.Regexp{
 		regexp.MustCompile(`\x1b\[KPIN`),
+		regexp.MustCompile(`\x1b\[KCalc~ \.\.\. \d+\.\d+% \[[#.]{23}] \[\d+ in [\d.]+ms]`),
+		regexp.MustCompile(`\x1b\[KDown~ \.\.\. \d+\.\d+% \[[#.]{23}] \[\d+B in [\d.]+ms]`),
+		regexp.MustCompile(`\x1b\[KTran~ \.\.\. \d+\.\d+% \[[#.]{23}] \[\$\d+ in [\d.]+ms]`),
+		regexp.MustCompile(`\x1b\[KCalc~ \.\.\. done! \[\d+\.\d+K in [\d.]+ms]`),
+		regexp.MustCompile(`\x1b\[KDown~ \.\.\. done! \[\d+\.\d+KB in [\d.]+ms]`),
+		regexp.MustCompile(`\x1b\[KTran~ \.\.\. done! \[\$\d+\.\d+K in [\d.]+ms]`),
+	}
+	out := renderOutput.String()
+	for _, expectedOutPattern := range expectedOutPatterns {
+		if !expectedOutPattern.MatchString(out) {
+			assert.Fail(t, "Failed to find a pattern in the Output.", expectedOutPattern.String())
+		}
+	}
+	showOutputOnFailure(t, out)
+}
+
+func TestProgress_RenderSomeTrackers_WithPinMessage_MultiLines(t *testing.T) {
+	renderOutput := outputWriter{}
+
+	pw := generateWriter()
+	pw.SetMessageWidth(5)
+	pw.SetOutputWriter(&renderOutput)
+	pw.SetTrackerPosition(PositionRight)
+	pw.Style().Visibility.Pin = true
+	pw.SetPinMessage("PIN", "PIN2")
+	go trackSomething(pw, &Tracker{Message: "Calculating Total   # 1\r", Total: 1000, Units: UnitsDefault})
+	go trackSomething(pw, &Tracker{Message: "Downloading File\t# 2", Total: 1000, Units: UnitsBytes})
+	go trackSomething(pw, &Tracker{Message: "Transferring Amount # 3", Total: 1000, Units: UnitsCurrencyDollar})
+	renderAndWait(pw, false)
+
+	expectedOutPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`\x1b\[KPIN`),
+		regexp.MustCompile(`\x1b\[KPIN2`),
 		regexp.MustCompile(`\x1b\[KCalc~ \.\.\. \d+\.\d+% \[[#.]{23}] \[\d+ in [\d.]+ms]`),
 		regexp.MustCompile(`\x1b\[KDown~ \.\.\. \d+\.\d+% \[[#.]{23}] \[\d+B in [\d.]+ms]`),
 		regexp.MustCompile(`\x1b\[KTran~ \.\.\. \d+\.\d+% \[[#.]{23}] \[\$\d+ in [\d.]+ms]`),

--- a/progress/style.go
+++ b/progress/style.go
@@ -118,6 +118,7 @@ var (
 // StyleColors defines what colors to use for various parts of the Progress and
 // Tracker texts.
 type StyleColors struct {
+	Pin     text.Colors // color of the pin message
 	Message text.Colors // message text colors
 	Error   text.Colors // error text colors
 	Percent text.Colors // percentage text colors
@@ -135,6 +136,7 @@ var (
 	// StyleColorsExample defines a few choice color options. Use this is just
 	// as an example to customize the Tracker/text colors.
 	StyleColorsExample = StyleColors{
+		Pin:     text.Colors{text.FgBlue},
 		Message: text.Colors{text.FgWhite},
 		Error:   text.Colors{text.FgRed},
 		Percent: text.Colors{text.FgHiRed},
@@ -190,6 +192,7 @@ var (
 
 // StyleVisibility controls what gets shown and what gets hidden.
 type StyleVisibility struct {
+	Pin            bool // pin message
 	ETA            bool // ETA for each tracker
 	ETAOverall     bool // ETA for the overall tracker
 	Percentage     bool // tracker progress percentage value
@@ -204,6 +207,7 @@ type StyleVisibility struct {
 var (
 	// StyleVisibilityDefault defines sane defaults for the Visibility.
 	StyleVisibilityDefault = StyleVisibility{
+		Pin:            false,
 		ETA:            false,
 		ETAOverall:     true,
 		Percentage:     true,

--- a/progress/writer.go
+++ b/progress/writer.go
@@ -15,6 +15,7 @@ type Writer interface {
 	LengthActive() int
 	LengthDone() int
 	LengthInQueue() int
+	PinMessage() string
 	Log(msg string, a ...interface{})
 	SetAutoStop(autoStop bool)
 	SetMessageWidth(width int)
@@ -37,6 +38,7 @@ type Writer interface {
 	// Deprecated: in favor of Style().Visibility.Value
 	ShowValue(show bool)
 	SetUpdateFrequency(frequency time.Duration)
+	SetPinMessage(pin string)
 	Stop()
 	Style() *Style
 	Render()

--- a/progress/writer.go
+++ b/progress/writer.go
@@ -38,7 +38,7 @@ type Writer interface {
 	// Deprecated: in favor of Style().Visibility.Value
 	ShowValue(show bool)
 	SetUpdateFrequency(frequency time.Duration)
-	SetPinMessage(pin string)
+	SetPinMessage(messages ...string)
 	Stop()
 	Style() *Style
 	Render()


### PR DESCRIPTION
## Proposed Changes
Add pin message for progress bar, It will be displayed at the top of all active trackers.

Developers can display some dynamic information here (e.g. CPU, load, memory)
