### PR TITLE
progress: "pin"->"pinned"; sort interfaces/structs

### DIFF
--- a/cmd/demo-progress/demo.go
+++ b/cmd/demo-progress/demo.go
@@ -21,7 +21,7 @@ var (
 	flagNumTrackers        = flag.Int("num-trackers", 13, "Number of Trackers")
 	flagShowSpeed          = flag.Bool("show-speed", false, "Show the tracker speed?")
 	flagShowSpeedOverall   = flag.Bool("show-speed-overall", false, "Show the overall tracker speed?")
-	flagShowPin            = flag.Bool("show-pin", false, "Show the pin message?")
+	flagShowPinned         = flag.Bool("show-pinned", false, "Show a pinned message?")
 	flagRandomFail         = flag.Bool("rnd-fail", false, "Introduce random failures in tracking")
 	flagRandomLogs         = flag.Bool("rnd-logs", false, "Output random logs in the middle of tracking")
 
@@ -34,6 +34,7 @@ var (
 		text.FgCyan,
 		text.FgWhite,
 	}
+	timeStart = time.Now()
 )
 
 func getMessage(idx int64, units *progress.Units) string {
@@ -88,8 +89,12 @@ func trackSomething(pw progress.Writer, idx int64, updateMessage bool) {
 			} else if *flagRandomFail && rand.Float64() < 0.1 {
 				tracker.MarkAsErrored()
 			}
-			t := time.Now().Format(time.RFC3339)
-			pw.SetPinMessage(fmt.Sprintf("Current Time: %s", t), fmt.Sprintf("CURRENT TIME: %s", t))
+			pw.SetPinnedMessages(
+				fmt.Sprintf("Current Time: %s | Total Time: %s",
+					time.Now().Format(time.RFC3339),
+					time.Now().Sub(timeStart).Round(time.Second),
+				),
+			)
 		case <-updateTicker:
 			if updateMessage {
 				rndIdx := rand.Intn(len(messageColors))
@@ -126,7 +131,7 @@ func main() {
 	pw.Style().Visibility.Time = !*flagHideTime
 	pw.Style().Visibility.TrackerOverall = !*flagHideOverallTracker
 	pw.Style().Visibility.Value = !*flagHideValue
-	pw.Style().Visibility.Pin = *flagShowPin
+	pw.Style().Visibility.Pinned = *flagShowPinned
 
 	// call Render() in async mode; yes we don't have any trackers at the moment
 	go pw.Render()

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -95,6 +95,14 @@ func TestProgress_Log(t *testing.T) {
 	assert.Len(t, p.logsToRender, 1)
 }
 
+func TestProgress_PinnedMessages(t *testing.T) {
+	p := Progress{}
+	assert.Nil(t, p.pinnedMessages)
+
+	p.pinnedMessages = []string{"pin1", "pin2"}
+	assert.Equal(t, []string{"pin1", "pin2"}, p.PinnedMessages())
+}
+
 func TestProgress_SetAutoStop(t *testing.T) {
 	p := Progress{}
 	assert.False(t, p.autoStop)
@@ -117,6 +125,14 @@ func TestProgress_SetOutputWriter(t *testing.T) {
 
 	p.SetOutputWriter(os.Stdout)
 	assert.Equal(t, os.Stdout, p.outputWriter)
+}
+
+func TestProgress_SetPinnedMessages(t *testing.T) {
+	p := Progress{}
+	assert.Nil(t, p.pinnedMessages)
+
+	p.SetPinnedMessages("pin1", "pin2")
+	assert.Equal(t, []string{"pin1", "pin2"}, p.pinnedMessages)
 }
 
 func TestProgress_SetSortBy(t *testing.T) {
@@ -229,20 +245,4 @@ func TestProgress_Style(t *testing.T) {
 
 	assert.NotNil(t, p.Style())
 	assert.Equal(t, StyleDefault.Name, p.Style().Name)
-}
-
-func TestProgress_SetPinMessage(t *testing.T) {
-	p := Progress{}
-	assert.Nil(t, p.pinMessage)
-
-	p.SetPinMessage("pin1", "pin2")
-	assert.Equal(t, []string{"pin1", "pin2"}, p.pinMessage)
-}
-
-func TestProgress_PinMessage(t *testing.T) {
-	p := Progress{}
-	assert.Nil(t, p.pinMessage)
-
-	p.pinMessage = []string{"pin1", "pin2"}
-	assert.Equal(t, "pin1\npin2", p.PinMessage())
 }

--- a/progress/render_test.go
+++ b/progress/render_test.go
@@ -823,8 +823,8 @@ func TestProgress_RenderSomeTrackers_WithPinMessage_OneLine(t *testing.T) {
 	pw.SetMessageWidth(5)
 	pw.SetOutputWriter(&renderOutput)
 	pw.SetTrackerPosition(PositionRight)
-	pw.Style().Visibility.Pin = true
-	pw.SetPinMessage("PIN")
+	pw.Style().Visibility.Pinned = true
+	pw.SetPinnedMessages("PIN")
 	go trackSomething(pw, &Tracker{Message: "Calculating Total   # 1\r", Total: 1000, Units: UnitsDefault})
 	go trackSomething(pw, &Tracker{Message: "Downloading File\t# 2", Total: 1000, Units: UnitsBytes})
 	go trackSomething(pw, &Tracker{Message: "Transferring Amount # 3", Total: 1000, Units: UnitsCurrencyDollar})
@@ -855,8 +855,8 @@ func TestProgress_RenderSomeTrackers_WithPinMessage_MultiLines(t *testing.T) {
 	pw.SetMessageWidth(5)
 	pw.SetOutputWriter(&renderOutput)
 	pw.SetTrackerPosition(PositionRight)
-	pw.Style().Visibility.Pin = true
-	pw.SetPinMessage("PIN", "PIN2")
+	pw.Style().Visibility.Pinned = true
+	pw.SetPinnedMessages("PIN", "PIN2")
 	go trackSomething(pw, &Tracker{Message: "Calculating Total   # 1\r", Total: 1000, Units: UnitsDefault})
 	go trackSomething(pw, &Tracker{Message: "Downloading File\t# 2", Total: 1000, Units: UnitsBytes})
 	go trackSomething(pw, &Tracker{Message: "Transferring Amount # 3", Total: 1000, Units: UnitsCurrencyDollar})

--- a/progress/style.go
+++ b/progress/style.go
@@ -118,10 +118,10 @@ var (
 // StyleColors defines what colors to use for various parts of the Progress and
 // Tracker texts.
 type StyleColors struct {
-	Pin     text.Colors // color of the pin message
 	Message text.Colors // message text colors
 	Error   text.Colors // error text colors
 	Percent text.Colors // percentage text colors
+	Pinned  text.Colors // color of the pin message
 	Stats   text.Colors // stats text (time, value) colors
 	Time    text.Colors // time text colors (overrides Stats)
 	Tracker text.Colors // tracker text colors
@@ -136,10 +136,10 @@ var (
 	// StyleColorsExample defines a few choice color options. Use this is just
 	// as an example to customize the Tracker/text colors.
 	StyleColorsExample = StyleColors{
-		Pin:     text.Colors{text.FgBlue},
 		Message: text.Colors{text.FgWhite},
 		Error:   text.Colors{text.FgRed},
 		Percent: text.Colors{text.FgHiRed},
+		Pinned:  text.Colors{text.BgHiBlack, text.Bold, text.Underline},
 		Stats:   text.Colors{text.FgHiBlack},
 		Time:    text.Colors{text.FgGreen},
 		Tracker: text.Colors{text.FgYellow},
@@ -192,10 +192,10 @@ var (
 
 // StyleVisibility controls what gets shown and what gets hidden.
 type StyleVisibility struct {
-	Pin            bool // pin message
 	ETA            bool // ETA for each tracker
 	ETAOverall     bool // ETA for the overall tracker
 	Percentage     bool // tracker progress percentage value
+	Pinned         bool // pin message
 	Speed          bool // tracker speed
 	SpeedOverall   bool // overall tracker speed
 	Time           bool // tracker time taken
@@ -207,10 +207,10 @@ type StyleVisibility struct {
 var (
 	// StyleVisibilityDefault defines sane defaults for the Visibility.
 	StyleVisibilityDefault = StyleVisibility{
-		Pin:            false,
 		ETA:            false,
 		ETAOverall:     true,
 		Percentage:     true,
+		Pinned:         true,
 		Speed:          false,
 		SpeedOverall:   false,
 		Time:           true,

--- a/progress/writer.go
+++ b/progress/writer.go
@@ -15,12 +15,13 @@ type Writer interface {
 	LengthActive() int
 	LengthDone() int
 	LengthInQueue() int
-	PinMessage() string
 	Log(msg string, a ...interface{})
+	PinnedMessages() []string
 	SetAutoStop(autoStop bool)
 	SetMessageWidth(width int)
 	SetNumTrackersExpected(numTrackers int)
 	SetOutputWriter(output io.Writer)
+	SetPinnedMessages(messages ...string)
 	SetSortBy(sortBy SortBy)
 	SetStyle(style Style)
 	SetTrackerLength(length int)
@@ -38,7 +39,6 @@ type Writer interface {
 	// Deprecated: in favor of Style().Visibility.Value
 	ShowValue(show bool)
 	SetUpdateFrequency(frequency time.Duration)
-	SetPinMessage(messages ...string)
 	Stop()
 	Style() *Style
 	Render()

--- a/text/direction_test.go
+++ b/text/direction_test.go
@@ -1,0 +1,13 @@
+package text
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDirection_Modifier(t *testing.T) {
+	assert.Equal(t, "", Default.Modifier())
+	assert.Equal(t, "\u202a", LeftToRight.Modifier())
+	assert.Equal(t, "\u202b", RightToLeft.Modifier())
+}


### PR DESCRIPTION
## Proposed Changes
  - use `Pinned` instead of `Pin` everywhere
  - sort functions, interfaces, structs alphabetically
