### PR TITLE
progress: support rendering trackers that haven't started yet

### DIFF
--- a/cmd/demo-progress/demo.go
+++ b/cmd/demo-progress/demo.go
@@ -23,6 +23,7 @@ var (
 	flagShowSpeedOverall   = flag.Bool("show-speed-overall", false, "Show the overall tracker speed?")
 	flagShowPinned         = flag.Bool("show-pinned", false, "Show a pinned message?")
 	flagRandomFail         = flag.Bool("rnd-fail", false, "Introduce random failures in tracking")
+	flagRandomDefer        = flag.Bool("rnd-defer", false, "Introduce random deferred starts")
 	flagRandomLogs         = flag.Bool("rnd-logs", false, "Output random logs in the middle of tracking")
 
 	messageColors = []text.Color{
@@ -71,12 +72,17 @@ func trackSomething(pw progress.Writer, idx int64, updateMessage bool) {
 
 	units := getUnits(idx)
 	message := getMessage(idx, units)
-	tracker := progress.Tracker{Message: message, Total: total, Units: *units}
+	tracker := progress.Tracker{Message: message, Total: total, Units: *units, DeferStart: *flagRandomDefer && rand.Float64() < 0.5}
 	if idx == int64(*flagNumTrackers) {
 		tracker.Total = 0
 	}
 
 	pw.AppendTracker(&tracker)
+
+	if tracker.DeferStart {
+		time.Sleep(3 * time.Second)
+		tracker.Start()
+	}
 
 	ticker := time.Tick(time.Millisecond * 500)
 	updateTicker := time.Tick(time.Millisecond * 250)

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -67,7 +67,9 @@ const (
 // to a queue, which gets picked up by the Render logic in the next rendering
 // cycle.
 func (p *Progress) AppendTracker(t *Tracker) {
-	t.start()
+	if !t.DeferStart {
+		t.start()
+	}
 	p.overallTrackerMutex.Lock()
 	defer p.overallTrackerMutex.Unlock()
 

--- a/progress/tracker_test.go
+++ b/progress/tracker_test.go
@@ -68,6 +68,28 @@ func TestTracker_IncrementWithError(t *testing.T) {
 	assert.True(t, tracker.IsDone())
 }
 
+func TestTracker_IsStarted(t *testing.T) {
+	tracker := Tracker{DeferStart: true}
+	assert.False(t, tracker.IsStarted())
+	tracker.Start()
+	assert.True(t, tracker.IsStarted())
+
+	tracker = Tracker{DeferStart: true}
+	assert.False(t, tracker.IsStarted())
+	tracker.Increment(1)
+	assert.True(t, tracker.IsStarted())
+
+	tracker = Tracker{DeferStart: true}
+	assert.False(t, tracker.IsStarted())
+	tracker.IncrementWithError(1)
+	assert.True(t, tracker.IsStarted())
+
+	tracker = Tracker{DeferStart: true}
+	assert.False(t, tracker.IsStarted())
+	tracker.SetValue(1)
+	assert.True(t, tracker.IsStarted())
+}
+
 func TestTracker_IsDone(t *testing.T) {
 	tracker := Tracker{Total: 10}
 	assert.False(t, tracker.IsDone())


### PR DESCRIPTION
## Proposed Changes
Support displaying trackers that haven't started yet.

I have a complex process that includes tasks that depend on the completion of other tasks. I'd like to display trackers for these deferred tasks without actually starting the clock or animating the indeterminate ones.

This PR has:
* no breaking changes
* no race conditions (AFAIK)
* full unit test coverage
* demo options to see it in action