### PR TITLE
progress: secondary sort by start time

### DIFF
--- a/progress/tracker_sort.go
+++ b/progress/tracker_sort.go
@@ -34,15 +34,15 @@ func (sb SortBy) Sort(trackers []*Tracker) {
 	case SortByMessage:
 		sort.Sort(sortByMessage(trackers))
 	case SortByMessageDsc:
-		sort.Sort(sortByMessageDsc(trackers))
+		sort.Sort(sortDsc{sortByMessage(trackers)})
 	case SortByPercent:
 		sort.Sort(sortByPercent(trackers))
 	case SortByPercentDsc:
-		sort.Sort(sortByPercentDsc(trackers))
+		sort.Sort(sortDsc{sortByPercent(trackers)})
 	case SortByValue:
 		sort.Sort(sortByValue(trackers))
 	case SortByValueDsc:
-		sort.Sort(sortByValueDsc(trackers))
+		sort.Sort(sortDsc{sortByValue(trackers)})
 	default:
 		// no sort
 	}
@@ -54,32 +54,28 @@ func (sb sortByMessage) Len() int           { return len(sb) }
 func (sb sortByMessage) Swap(i, j int)      { sb[i], sb[j] = sb[j], sb[i] }
 func (sb sortByMessage) Less(i, j int) bool { return sb[i].message() < sb[j].message() }
 
-type sortByMessageDsc []*Tracker
-
-func (sb sortByMessageDsc) Len() int           { return len(sb) }
-func (sb sortByMessageDsc) Swap(i, j int)      { sb[i], sb[j] = sb[j], sb[i] }
-func (sb sortByMessageDsc) Less(i, j int) bool { return sb[i].message() > sb[j].message() }
-
 type sortByPercent []*Tracker
 
 func (sb sortByPercent) Len() int           { return len(sb) }
 func (sb sortByPercent) Swap(i, j int)      { sb[i], sb[j] = sb[j], sb[i] }
-func (sb sortByPercent) Less(i, j int) bool { return sb[i].PercentDone() < sb[j].PercentDone() }
-
-type sortByPercentDsc []*Tracker
-
-func (sb sortByPercentDsc) Len() int           { return len(sb) }
-func (sb sortByPercentDsc) Swap(i, j int)      { sb[i], sb[j] = sb[j], sb[i] }
-func (sb sortByPercentDsc) Less(i, j int) bool { return sb[i].PercentDone() > sb[j].PercentDone() }
+func (sb sortByPercent) Less(i, j int) bool {
+	if sb[i].PercentDone() == sb[j].PercentDone() {
+		return sb[i].timeStart.Before(sb[j].timeStart)
+	}
+	return sb[i].PercentDone() < sb[j].PercentDone()
+}
 
 type sortByValue []*Tracker
 
 func (sb sortByValue) Len() int           { return len(sb) }
 func (sb sortByValue) Swap(i, j int)      { sb[i], sb[j] = sb[j], sb[i] }
-func (sb sortByValue) Less(i, j int) bool { return sb[i].value < sb[j].value }
+func (sb sortByValue) Less(i, j int) bool {
+	if sb[i].value == sb[j].value {
+		return sb[i].timeStart.Before(sb[j].timeStart)
+	}
+	return sb[i].value < sb[j].value
+}
 
-type sortByValueDsc []*Tracker
+type sortDsc struct{ sort.Interface }
 
-func (sb sortByValueDsc) Len() int           { return len(sb) }
-func (sb sortByValueDsc) Swap(i, j int)      { sb[i], sb[j] = sb[j], sb[i] }
-func (sb sortByValueDsc) Less(i, j int) bool { return sb[i].value > sb[j].value }
+func (sd sortDsc) Less(i, j int) bool { return !sd.Interface.Less(i, j) }

--- a/progress/tracker_sort_test.go
+++ b/progress/tracker_sort_test.go
@@ -2,6 +2,7 @@ package progress
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -11,40 +12,48 @@ func TestSortBy(t *testing.T) {
 		{Message: "Downloading File # 2", Total: 1000, value: 300},
 		{Message: "Downloading File # 1", Total: 1000, value: 100},
 		{Message: "Downloading File # 3", Total: 1000, value: 500},
+		{Message: "Downloading File # 4", Total: 1000, value: 300, timeStart: time.Now()},
 	}
 
 	SortByNone.Sort(trackers)
 	assert.Equal(t, "Downloading File # 2", trackers[0].Message)
 	assert.Equal(t, "Downloading File # 1", trackers[1].Message)
 	assert.Equal(t, "Downloading File # 3", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 4", trackers[3].Message)
 
 	SortByMessage.Sort(trackers)
 	assert.Equal(t, "Downloading File # 1", trackers[0].Message)
 	assert.Equal(t, "Downloading File # 2", trackers[1].Message)
 	assert.Equal(t, "Downloading File # 3", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 4", trackers[3].Message)
 
 	SortByMessageDsc.Sort(trackers)
-	assert.Equal(t, "Downloading File # 3", trackers[0].Message)
-	assert.Equal(t, "Downloading File # 2", trackers[1].Message)
-	assert.Equal(t, "Downloading File # 1", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 4", trackers[0].Message)
+	assert.Equal(t, "Downloading File # 3", trackers[1].Message)
+	assert.Equal(t, "Downloading File # 2", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 1", trackers[3].Message)
 
 	SortByPercent.Sort(trackers)
 	assert.Equal(t, "Downloading File # 1", trackers[0].Message)
 	assert.Equal(t, "Downloading File # 2", trackers[1].Message)
-	assert.Equal(t, "Downloading File # 3", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 4", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 3", trackers[3].Message)
 
 	SortByPercentDsc.Sort(trackers)
 	assert.Equal(t, "Downloading File # 3", trackers[0].Message)
-	assert.Equal(t, "Downloading File # 2", trackers[1].Message)
-	assert.Equal(t, "Downloading File # 1", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 4", trackers[1].Message)
+	assert.Equal(t, "Downloading File # 2", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 1", trackers[3].Message)
 
 	SortByValue.Sort(trackers)
 	assert.Equal(t, "Downloading File # 1", trackers[0].Message)
 	assert.Equal(t, "Downloading File # 2", trackers[1].Message)
-	assert.Equal(t, "Downloading File # 3", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 4", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 3", trackers[3].Message)
 
 	SortByValueDsc.Sort(trackers)
 	assert.Equal(t, "Downloading File # 3", trackers[0].Message)
-	assert.Equal(t, "Downloading File # 2", trackers[1].Message)
-	assert.Equal(t, "Downloading File # 1", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 4", trackers[1].Message)
+	assert.Equal(t, "Downloading File # 2", trackers[2].Message)
+	assert.Equal(t, "Downloading File # 1", trackers[3].Message)
 }


### PR DESCRIPTION
## Proposed Changes
Fixes the slightly messy deferred start sorting issue described in #270 by adding a secondary `timeStart` tracker sort in the renderer. Also removes a little dupe code by using a generic sort reverser wrapper type `sortDsc`.

![progress-oddity](https://github.com/jedib0t/go-pretty/assets/249604/5e262a82-4cdd-446d-b7ec-9f364126ae51)