### PR TITLE
progress: Stability fix for descending sorts

### DIFF
--- a/progress/tracker_sort.go
+++ b/progress/tracker_sort.go
@@ -78,4 +78,4 @@ func (sb sortByValue) Less(i, j int) bool {
 
 type sortDsc struct{ sort.Interface }
 
-func (sd sortDsc) Less(i, j int) bool { return !sd.Interface.Less(i, j) }
+func (sd sortDsc) Less(i, j int) bool { return !sd.Interface.Less(i, j) && sd.Interface.Less(j, i) }


### PR DESCRIPTION
Very simple fix for a sort stability issue mentioned in #271 - deferred trackers no longer randomly jump around.