### PR TITLE
progress: Overall ETA never less than max ETA

### DIFF
--- a/progress/tracker.go
+++ b/progress/tracker.go
@@ -35,6 +35,7 @@ type Tracker struct {
 	timeStart time.Time
 	timeStop  time.Time
 	value     int64
+	minETA    time.Duration
 }
 
 // ETA returns the expected time of "arrival" or completion of this tracker. It
@@ -56,7 +57,11 @@ func (t *Tracker) ETA() time.Duration {
 	if pDone == 0 {
 		return time.Duration(0)
 	}
-	return time.Duration((int64(timeTaken) / pDone) * (100 - pDone))
+	eta := time.Duration((int64(timeTaken) / pDone) * (100 - pDone))
+	if eta < t.minETA {
+		eta = t.minETA
+	}
+	return eta
 }
 
 // Increment updates the current value of the task being tracked.

--- a/table/render_markdown.go
+++ b/table/render_markdown.go
@@ -6,13 +6,12 @@ import (
 )
 
 // RenderMarkdown renders the Table in Markdown format. Example:
-//
-//	| # | First Name | Last Name | Salary |  |
-//	| ---:| --- | --- | ---:| --- |
-//	| 1 | Arya | Stark | 3000 |  |
-//	| 20 | Jon | Snow | 2000 | You know nothing, Jon Snow! |
-//	| 300 | Tyrion | Lannister | 5000 |  |
-//	|  |  | Total | 10000 |  |
+//  | # | First Name | Last Name | Salary |  |
+//  | ---:| --- | --- | ---:| --- |
+//  | 1 | Arya | Stark | 3000 |  |
+//  | 20 | Jon | Snow | 2000 | You know nothing, Jon Snow! |
+//  | 300 | Tyrion | Lannister | 5000 |  |
+//  |  |  | Total | 10000 |  |
 func (t *Table) RenderMarkdown() string {
 	t.initForRender()
 

--- a/table/table.go
+++ b/table/table.go
@@ -164,15 +164,14 @@ func (t *Table) AppendRows(rows []Row, config ...RowConfig) {
 // append is a separator, it will not be rendered in addition to the usual table
 // separator.
 //
-// ******************************************************************************
+//******************************************************************************
 // Please note the following caveats:
-//  1. SetPageSize(): this may end up creating consecutive separator rows near
-//     the end of a page or at the beginning of a page
-//  2. SortBy(): since SortBy could inherently alter the ordering of rows, the
-//     separators may not appear after the row it was originally intended to
-//     follow
-//
-// ******************************************************************************
+// 1. SetPageSize(): this may end up creating consecutive separator rows near
+//    the end of a page or at the beginning of a page
+// 2. SortBy(): since SortBy could inherently alter the ordering of rows, the
+//    separators may not appear after the row it was originally intended to
+//    follow
+//******************************************************************************
 func (t *Table) AppendSeparator() {
 	if t.separators == nil {
 		t.separators = make(map[int]bool)

--- a/text/transformer.go
+++ b/text/transformer.go
@@ -37,9 +37,9 @@ var (
 type Transformer func(val interface{}) string
 
 // NewNumberTransformer returns a number Transformer that:
-//   - transforms the number as directed by 'format' (ex.: %.2f)
-//   - colors negative values Red
-//   - colors positive values Green
+//   * transforms the number as directed by 'format' (ex.: %.2f)
+//   * colors negative values Red
+//   * colors positive values Green
 func NewNumberTransformer(format string) Transformer {
 	return func(val interface{}) string {
 		if valStr := transformInt(format, val); valStr != "" {


### PR DESCRIPTION
The current overall ETA doesn't really work because all the fast trackers finish quickly leaving the slow ones, meaning the current naive calculation always underestimates the ETA.

IMO the overall tracker ETA should never be less than the longest ETA of the active trackers. There are a couple of ways this could be done, but introducing a `maxETA` field on `Tracker` was the easiest without majorly refactoring the way overall trackers work.

Here are before and after graphs that show the ETA reported (blue) vs the actual ETA (orange) in my project. They both have a lot of instability initially but the second does a much better job at guestimating the ETA once it settles.

![progress-eta-change-before](https://github.com/jedib0t/go-pretty/assets/249604/9e5594fb-5baf-4b27-ba4a-e178a7ecc60e)
![progress-eta-change-after](https://github.com/jedib0t/go-pretty/assets/249604/812e2eeb-17aa-414e-9119-ff537921b682)

Note - this PR also includes some general code cleanup. Let me know if you'd like this separated.