### PR TITLE
table: handle negative WidthMax values; fixes #285

### DIFF
--- a/table/config.go
+++ b/table/config.go
@@ -71,7 +71,7 @@ type ColumnConfig struct {
 }
 
 func (c ColumnConfig) getWidthMaxEnforcer() WidthEnforcer {
-	if c.WidthMax == 0 {
+	if c.WidthMax <= 0 {
 		return widthEnforcerNone
 	}
 	if c.WidthMaxEnforcer != nil {

--- a/table/config_test.go
+++ b/table/config_test.go
@@ -34,6 +34,20 @@ func TestColumnConfig_getWidthMaxEnforcer(t *testing.T) {
 		assert.Equal(t, "1234567890", widthEnforcer("1234567890", 1000))
 	})
 
+	t.Run("negative width enforcer", func(t *testing.T) {
+		cc := ColumnConfig{
+			WidthMax: -10,
+		}
+
+		widthEnforcer := cc.getWidthMaxEnforcer()
+		assert.Equal(t, "1234567890", widthEnforcer("1234567890", 0))
+		assert.Equal(t, "1234567890", widthEnforcer("1234567890", 1))
+		assert.Equal(t, "1234567890", widthEnforcer("1234567890", 5))
+		assert.Equal(t, "1234567890", widthEnforcer("1234567890", 10))
+		assert.Equal(t, "1234567890", widthEnforcer("1234567890", 100))
+		assert.Equal(t, "1234567890", widthEnforcer("1234567890", 1000))
+	})
+
 	t.Run("custom width enforcer (1)", func(t *testing.T) {
 		cc := ColumnConfig{
 			WidthMax:         10,


### PR DESCRIPTION
## Proposed Changes
  - If a column's WidthMax attribute is set to negative, handle it similar to `0`

Fixes #285.
