### PR TITLE
fix(table): SuppressTrailingSpaces also removed spaces from the beginning

### DIFF
--- a/table/render_test.go
+++ b/table/render_test.go
@@ -1222,10 +1222,10 @@ func TestTable_Render_SuppressTrailingSpaces(t *testing.T) {
 
 	tw.Style().Options = OptionsNoBordersAndSeparators
 	compareOutput(t, tw.Render(), `
-ID    TEXT1                                   DATE              TEXT2
-U2    Hey                                     2021-04-19 13:37  Yuh yuh yuh
-S12   Uhhhh                                   2021-04-19 13:37  Some dummy data here
-R123  Lobsters                                2021-04-19 13:37  I like lobsters
-R123  Some big name here and it's pretty big  2021-04-19 13:37  Abcdefghijklmnopqrstuvwxyz
-R123  Small name                              2021-04-19 13:37  Abcdefghijklmnopqrstuvwxyz`)
+ ID    TEXT1                                   DATE              TEXT2
+ U2    Hey                                     2021-04-19 13:37  Yuh yuh yuh
+ S12   Uhhhh                                   2021-04-19 13:37  Some dummy data here
+ R123  Lobsters                                2021-04-19 13:37  I like lobsters
+ R123  Some big name here and it's pretty big  2021-04-19 13:37  Abcdefghijklmnopqrstuvwxyz
+ R123  Small name                              2021-04-19 13:37  Abcdefghijklmnopqrstuvwxyz`)
 }

--- a/table/table.go
+++ b/table/table.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode"
 
 	"github.com/jedib0t/go-pretty/v6/text"
 )
@@ -691,7 +692,11 @@ func (t *Table) render(out *strings.Builder) string {
 		var trimmed []string
 		sc := bufio.NewScanner(strings.NewReader(outStr))
 		for sc.Scan() {
-			trimmed = append(trimmed, strings.TrimSpace(sc.Text()))
+			trimmed = append(trimmed, strings.TrimRightFunc(
+				sc.Text(), func(r rune) bool {
+					return unicode.IsSpace(r)
+				},
+			))
 		}
 		outStr = strings.Join(trimmed, "\n")
 	}


### PR DESCRIPTION
## Proposed Changes
`mytable.SuppressTrailingSpaces()` suppressing not only trailing spaces, but also spaces from the beginning. This fixes it.

## Before fix

```
RESOURCE (→READY)               STATE    INFO
Deployment/lesikovtestttt       WAITING  Ready:0/1
• Pod/lesikovtestttt-78568f8d  CREATED  Status:CrashLoopBack
77-dkznh                                 Off  Errors:1  LastE
rror:"CrashLoopBackO
ff: back-off 5m0s re
starting failed cont
ainer=alpine pod=les
ikovtestttt-78568f8d
77-dkznh_nelm-basic(
a1e1ac7e-c64d-4531-9
d0d-b20b5e9f0a61)"
```

## After fix

```
RESOURCE (→READY)               STATE    INFO
Deployment/lesikovtestttt       WAITING  Ready:0/1
 • Pod/lesikovtestttt-78568f8d  CREATED  Status:CrashLoopBack
77-dkznh                                 Off  Errors:1  LastE
                                         rror:"CrashLoopBackO
                                         ff: back-off 2m40s r
                                         estarting failed con
                                         tainer=alpine pod=le
                                         sikovtestttt-78568f8
                                         d77-dkznh_nelm-basic
                                         (a1e1ac7e-c64d-4531-
                                         9d0d-b20b5e9f0a61)"
```