### PR TITLE
Consider empty cells to be not non-numeric

### DIFF
--- a/table/render_init.go
+++ b/table/render_init.go
@@ -24,7 +24,7 @@ func (t *Table) analyzeAndStringify(row Row, hint renderHint) rowStr {
 	rowOut := make(rowStr, len(row))
 	for colIdx, col := range row {
 		// if the column is not a number, keep track of it
-		if !hint.isHeaderRow && !hint.isFooterRow && !t.columnIsNonNumeric[colIdx] && !isNumber(col) {
+		if !hint.isHeaderRow && !hint.isFooterRow && !t.columnIsNonNumeric[colIdx] && !(isNumber(col) || isEmpty(col) {
 			t.columnIsNonNumeric[colIdx] = true
 		}
 

--- a/table/render_init.go
+++ b/table/render_init.go
@@ -24,7 +24,7 @@ func (t *Table) analyzeAndStringify(row Row, hint renderHint) rowStr {
 	rowOut := make(rowStr, len(row))
 	for colIdx, col := range row {
 		// if the column is not a number, keep track of it
-		if !hint.isHeaderRow && !hint.isFooterRow && !t.columnIsNonNumeric[colIdx] && !(isNumber(col) || isEmpty(col) {
+		if !hint.isHeaderRow && !hint.isFooterRow && !t.columnIsNonNumeric[colIdx] && !(isNumber(col) || isEmpty(col)) {
 			t.columnIsNonNumeric[colIdx] = true
 		}
 

--- a/table/util.go
+++ b/table/util.go
@@ -2,6 +2,7 @@ package table
 
 import (
 	"reflect"
+	"fmt"
 )
 
 // AutoIndexColumnID returns a unique Column ID/Name for the given Column Number.
@@ -38,6 +39,14 @@ func isNumber(x interface{}) bool {
 		return true
 	}
 	return false
+}
+
+// isEmpty returns true if the argument is an empty string or nil
+func isEmpty(x interface{}) bool {
+	if x == nil {
+		return true
+	}
+	return fmt.Sprintf("%v", x) == ""
 }
 
 type mergedColumnIndices map[int]map[int]bool

--- a/table/util.go
+++ b/table/util.go
@@ -1,8 +1,8 @@
 package table
 
 import (
-	"reflect"
 	"fmt"
+	"reflect"
 )
 
 // AutoIndexColumnID returns a unique Column ID/Name for the given Column Number.


### PR DESCRIPTION
## Proposed Changes

By adding a new utility function "isEmpty", which returns true for values rendered as zero-length strings and for `nil` values, numerical columns will remain numerical when there are only numbers or empty cells.

Fixes #299.
