### PR TITLE
table: add DoNotFillSpaceWhenEndOfLine option

### DIFF
--- a/table/style.go
+++ b/table/style.go
@@ -766,6 +766,19 @@ type Options struct {
 	//  │     │            │ TOTAL     │  10000 │                             │
 	//  └─────┴────────────┴───────────┴────────┴─────────────────────────────┘
 	SeparateRows bool
+
+	// DoNotFillSpaceWhenEndOfLine disables filling the space at the end of each
+	// line for AlignCenter and AlignLeft.It should be used when not draw border.
+	// Example of a table where it is enabled:
+	//  ┌─────┬────────────┬───────────┬────────┬─────────────────────────────┐
+	//  │   # │ FIRST NAME │ LAST NAME │ SALARY ││
+	//  ├─────┼────────────┼───────────┼────────┼─────────────────────────────┤
+	//  │   1 │ Arya       │ Stark     │   3000 ││
+	//  │  20 │ Jon        │ Snow      │   2000 │ You know nothing, Jon Snow! │
+	//  │ 300 │ Tyrion     │ Lannister │   5000 │test│
+	//  │     │            │ TOTAL     │  10000 │anothertest│
+	//  └─────┴────────────┴───────────┴────────┴─────────────────────────────┘
+	DoNotFillSpaceWhenEndOfLine bool
 }
 
 var (

--- a/table/table.go
+++ b/table/table.go
@@ -323,6 +323,8 @@ func (t *Table) getAlign(colIdx int, hint renderHint) text.Align {
 			align = text.AlignRight
 		} else if hint.isAutoIndexRow {
 			align = text.AlignCenter
+		} else if t.style.Options.DoNotFillSpaceWhenEndOfLine && t.isLastColumn(colIdx) {
+			align = text.AlignDisabled
 		}
 	}
 	return align
@@ -685,6 +687,10 @@ func (t *Table) hideColumns() map[int]int {
 
 func (t *Table) isIndexColumn(colIdx int, hint renderHint) bool {
 	return t.indexColumn == colIdx+1 || hint.isAutoIndexColumn
+}
+
+func (t *Table) isLastColumn(colIdx int) bool {
+	return colIdx == t.numColumns-1
 }
 
 func (t *Table) render(out *strings.Builder) string {

--- a/text/align.go
+++ b/text/align.go
@@ -12,12 +12,14 @@ type Align int
 
 // Align enumerations
 const (
-	AlignDefault Align = iota // same as AlignLeft
-	AlignLeft                 // "left        "
-	AlignCenter               // "   center   "
-	AlignJustify              // "justify   it"
-	AlignRight                // "       right"
-	AlignAuto                 // AlignRight for numbers, AlignLeft for the rest
+	AlignDefault                 Align = iota // same as AlignLeft
+	AlignLeft                                 // "left        "
+	AlignCenter                               // "   center   "
+	AlignJustify                              // "justify   it"
+	AlignRight                                // "       right"
+	AlignAuto                                 // AlignRight for numbers, AlignLeft for the rest
+	AlignDisabled                             // "left"
+	AlignCenterWithoutRightSpace              // "   center"
 )
 
 // Apply aligns the text as directed. For ex.:
@@ -55,6 +57,12 @@ func (a Align) Apply(text string, maxLength int) string {
 		}
 	case AlignJustify:
 		return justifyText(text, sLenWoE, maxLength)
+	case AlignDisabled:
+		return text
+	case AlignCenterWithoutRightSpace:
+		if sLenWoE < maxLength {
+			return strings.Repeat(" ", (maxLength-sLenWoE+1)/2) + text
+		}
 	}
 	return fmt.Sprintf("%"+strconv.Itoa(maxLength+numEscChars)+"s", text)
 }


### PR DESCRIPTION
## Proposed Changes
  - Allow not fill space on the last column. It is useful to draw table without border when table is wider then screen

Fixes #<insert Issue # here if applicable>.
before:
![pic 2024-04-10 20-58-56](https://github.com/jedib0t/go-pretty/assets/20392070/94ee632e-8529-4b8e-885b-10055eed8651)
after:
![pic 2024-04-10 20-58-08](https://github.com/jedib0t/go-pretty/assets/20392070/691b505e-9d05-48ca-9c6b-1223422a3856)
