### PR TITLE
table: ignore non-printable characters when suppressing empty columns

### DIFF
--- a/table/render_init.go
+++ b/table/render_init.go
@@ -3,6 +3,7 @@ package table
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/jedib0t/go-pretty/v6/text"
 )
@@ -255,7 +256,15 @@ func (t *Table) initForRenderSuppressColumns() {
 	shouldSuppressColumn := func(colIdx int) bool {
 		for _, row := range t.rows {
 			if colIdx < len(row) && row[colIdx] != "" {
-				return false
+				// Columns may contain non-printable characters. For example
+				// the text.Direction modifiers. These should not be considered
+				// when deciding to suppress a column.
+				for _, r := range row[colIdx] {
+					if unicode.IsPrint(r) {
+						return false
+					}
+				}
+				return true
 			}
 		}
 		return true

--- a/table/render_test.go
+++ b/table/render_test.go
@@ -1165,6 +1165,22 @@ func TestTable_Render_SuppressEmptyColumns(t *testing.T) {
 ├─────┼────────────┼────────┼─────────────────────────────┤
 │     │            │  10000 │                             │
 └─────┴────────────┴────────┴─────────────────────────────┘`)
+
+	tw.SetStyle(Style{
+		Format: FormatOptions{
+			Direction: text.LeftToRight,
+		},
+	})
+	// Columns with non-printable characters should still be suppressed.
+	compareOutput(t, tw.Render(), strings.Join([]string{
+		"\u202a  \u202a#\u202aFirst Name\u202aSalary                           ",
+		"\u202a  \u202a1\u202aArya        \u202a3000                           ",
+		"\u202a \u202a20\u202aJon         \u202a2000\u202aYou know nothing, Jon Snow!",
+		"\u202a\u202a300\u202aTyrion      \u202a5000                           ",
+		"\u202a \u202a11\u202aSansa       \u202a6000                           ",
+		"\u202a   \u202a\u202a           \u202a10000                           ",
+	}, "\n"))
+
 }
 
 func TestTable_Render_TableWithinTable(t *testing.T) {


### PR DESCRIPTION
## Proposed Changes

This change ensures that non-printable characters (e.g., text direction markers) are ignored when determining whether to suppress empty columns. This is required to use FormatOptions.Direction in conjunction with SuppressEmptyColumns().