### PR TITLE
Allow row painting by index

### DIFF
--- a/table/render_init.go
+++ b/table/render_init.go
@@ -222,6 +222,9 @@ func (t *Table) initForRenderRows() {
 	// auto-index: calc the index column's max length
 	t.autoIndexVIndexMaxLength = len(fmt.Sprint(len(t.rowsRaw)))
 
+	// sort the rows as requested
+	t.initForRenderSortRows()
+
 	// stringify all the rows to make it easy to render
 	if t.rowPainter != nil {
 		t.rowsColors = make([]text.Colors, len(t.rowsRaw))
@@ -229,9 +232,6 @@ func (t *Table) initForRenderRows() {
 	t.rows = t.initForRenderRowsStringify(t.rowsRaw, renderHint{})
 	t.rowsFooter = t.initForRenderRowsStringify(t.rowsFooterRaw, renderHint{isFooterRow: true})
 	t.rowsHeader = t.initForRenderRowsStringify(t.rowsHeaderRaw, renderHint{isHeaderRow: true})
-
-	// sort the rows as requested
-	t.initForRenderSortRows()
 
 	// suppress columns without any content
 	t.initForRenderSuppressColumns()
@@ -244,7 +244,7 @@ func (t *Table) initForRenderRowsStringify(rows []Row, hint renderHint) []rowStr
 	rowsStr := make([]rowStr, len(rows))
 	for idx, row := range rows {
 		if t.rowPainter != nil && hint.isRegularRow() {
-			t.rowsColors[idx] = t.rowPainter(row)
+			t.rowsColors[idx] = t.rowPainter(row, idx)
 		}
 		rowsStr[idx] = t.analyzeAndStringify(row, hint)
 	}

--- a/table/render_init.go
+++ b/table/render_init.go
@@ -226,7 +226,6 @@ func (t *Table) initForRenderRows() {
 	if t.rowPainter != nil || t.indexedRowPainter != nil {
 		t.rowsColors = make([]text.Colors, len(t.rowsRaw))
 	}
-
 	t.rows = t.initForRenderRowsStringify(t.rowsRaw, renderHint{})
 	t.rowsFooter = t.initForRenderRowsStringify(t.rowsFooterRaw, renderHint{isFooterRow: true})
 	t.rowsHeader = t.initForRenderRowsStringify(t.rowsHeaderRaw, renderHint{isHeaderRow: true})
@@ -267,7 +266,6 @@ func (t *Table) initForRenderSortRows() {
 
 	// sort the rows
 	sortedRowIndices := t.getSortedRowIndices()
-
 	sortedRows := make([]rowStr, len(t.rows))
 	for idx := range t.rows {
 		sortedRows[idx] = t.rows[sortedRowIndices[idx]]
@@ -279,7 +277,6 @@ func (t *Table) initForRenderSortRows() {
 		sortedRowsColors := make([]text.Colors, len(t.rows))
 		for idx := range t.rows {
 			sortedRowsColors[idx] = t.rowsColors[sortedRowIndices[idx]]
-
 			if t.indexedRowPainter != nil {
 				sortedRowsColors[idx] = t.indexedRowPainter(idx)
 			}

--- a/table/render_init.go
+++ b/table/render_init.go
@@ -247,7 +247,6 @@ func (t *Table) initForRenderRowsStringify(rows []Row, hint renderHint) []rowStr
 		if t.rowPainter != nil && hint.isRegularRow() {
 			t.rowsColors[idx] = t.rowPainter(row)
 		}
-
 		rowsStr[idx] = t.analyzeAndStringify(row, hint)
 	}
 	return rowsStr
@@ -268,7 +267,7 @@ func (t *Table) initForRenderSortRows() {
 
 	// sort the rows
 	sortedRowIndices := t.getSortedRowIndices()
-	t.sortedRowIndices = sortedRowIndices
+
 	sortedRows := make([]rowStr, len(t.rows))
 	for idx := range t.rows {
 		sortedRows[idx] = t.rows[sortedRowIndices[idx]]

--- a/table/render_init.go
+++ b/table/render_init.go
@@ -222,16 +222,17 @@ func (t *Table) initForRenderRows() {
 	// auto-index: calc the index column's max length
 	t.autoIndexVIndexMaxLength = len(fmt.Sprint(len(t.rowsRaw)))
 
-	// sort the rows as requested
-	t.initForRenderSortRows()
-
 	// stringify all the rows to make it easy to render
 	if t.rowPainter != nil || t.indexedRowPainter != nil {
 		t.rowsColors = make([]text.Colors, len(t.rowsRaw))
 	}
+
 	t.rows = t.initForRenderRowsStringify(t.rowsRaw, renderHint{})
 	t.rowsFooter = t.initForRenderRowsStringify(t.rowsFooterRaw, renderHint{isFooterRow: true})
 	t.rowsHeader = t.initForRenderRowsStringify(t.rowsHeaderRaw, renderHint{isHeaderRow: true})
+
+	// sort the rows as requested
+	t.initForRenderSortRows()
 
 	// suppress columns without any content
 	t.initForRenderSuppressColumns()
@@ -246,9 +247,7 @@ func (t *Table) initForRenderRowsStringify(rows []Row, hint renderHint) []rowStr
 		if t.rowPainter != nil && hint.isRegularRow() {
 			t.rowsColors[idx] = t.rowPainter(row)
 		}
-		if t.indexedRowPainter != nil && hint.isRegularRow() {
-			t.rowsColors[idx] = t.indexedRowPainter(idx)
-		}
+
 		rowsStr[idx] = t.analyzeAndStringify(row, hint)
 	}
 	return rowsStr
@@ -269,6 +268,7 @@ func (t *Table) initForRenderSortRows() {
 
 	// sort the rows
 	sortedRowIndices := t.getSortedRowIndices()
+	t.sortedRowIndices = sortedRowIndices
 	sortedRows := make([]rowStr, len(t.rows))
 	for idx := range t.rows {
 		sortedRows[idx] = t.rows[sortedRowIndices[idx]]
@@ -280,6 +280,10 @@ func (t *Table) initForRenderSortRows() {
 		sortedRowsColors := make([]text.Colors, len(t.rows))
 		for idx := range t.rows {
 			sortedRowsColors[idx] = t.rowsColors[sortedRowIndices[idx]]
+
+			if t.indexedRowPainter != nil {
+				sortedRowsColors[idx] = t.indexedRowPainter(idx)
+			}
 		}
 		t.rowsColors = sortedRowsColors
 	}

--- a/table/render_init.go
+++ b/table/render_init.go
@@ -226,7 +226,7 @@ func (t *Table) initForRenderRows() {
 	t.initForRenderSortRows()
 
 	// stringify all the rows to make it easy to render
-	if t.rowPainter != nil {
+	if t.rowPainter != nil || t.indexedRowPainter != nil {
 		t.rowsColors = make([]text.Colors, len(t.rowsRaw))
 	}
 	t.rows = t.initForRenderRowsStringify(t.rowsRaw, renderHint{})
@@ -244,7 +244,10 @@ func (t *Table) initForRenderRowsStringify(rows []Row, hint renderHint) []rowStr
 	rowsStr := make([]rowStr, len(rows))
 	for idx, row := range rows {
 		if t.rowPainter != nil && hint.isRegularRow() {
-			t.rowsColors[idx] = t.rowPainter(row, idx)
+			t.rowsColors[idx] = t.rowPainter(row)
+		}
+		if t.indexedRowPainter != nil && hint.isRegularRow() {
+			t.rowsColors[idx] = t.indexedRowPainter(idx)
 		}
 		rowsStr[idx] = t.analyzeAndStringify(row, hint)
 	}

--- a/table/render_test.go
+++ b/table/render_test.go
@@ -884,7 +884,7 @@ func TestTable_Render_RowPainter(t *testing.T) {
 	tw.AppendRow(testRowMultiLine)
 	tw.AppendFooter(testFooter)
 	tw.SetIndexColumn(1)
-	tw.SetRowPainter(func(row Row) text.Colors {
+	tw.SetRowPainter(func(row Row, idx int) text.Colors {
 		if salary, ok := row[3].(int); ok {
 			if salary > 3000 {
 				return text.Colors{text.BgYellow, text.FgBlack}

--- a/table/render_test.go
+++ b/table/render_test.go
@@ -930,6 +930,59 @@ func TestTable_Render_RowPainter(t *testing.T) {
 	assert.Equal(t, expectedOut, tw.Render())
 }
 
+func TestTable_Render_IndexedRowPainter(t *testing.T) {
+	tw := NewWriter()
+	tw.AppendHeader(testHeader)
+	tw.AppendRows(testRows)
+	tw.AppendRow(testRowMultiLine)
+	tw.AppendFooter(testFooter)
+	tw.SetIndexColumn(1)
+	tw.SetIndexedRowPainter(func(idx int) text.Colors {
+		if idx > -1 {
+			if idx == 3 {
+				return text.Colors{text.BgYellow, text.FgBlack}
+			} else if idx == 0 {
+				return text.Colors{text.BgRed, text.FgBlack}
+			}
+		}
+		return nil
+	})
+	tw.SetStyle(StyleLight)
+	tw.SortBy([]SortBy{{Name: "Salary", Mode: AscNumeric}})
+
+	expectedOutLines := []string{
+		"┌─────┬────────────┬───────────┬────────┬─────────────────────────────┐",
+		"│   # │ FIRST NAME │ LAST NAME │ SALARY │                             │",
+		"├─────┼────────────┼───────────┼────────┼─────────────────────────────┤",
+		"│   0 │\x1b[41;30m Winter     \x1b[0m│\x1b[41;30m Is        \x1b[0m│\x1b[41;30m      0 \x1b[0m│\x1b[41;30m Coming.                     \x1b[0m│",
+		"│     │\x1b[41;30m            \x1b[0m│\x1b[41;30m           \x1b[0m│\x1b[41;30m        \x1b[0m│\x1b[41;30m The North Remembers!        \x1b[0m│",
+		"│     │\x1b[41;30m            \x1b[0m│\x1b[41;30m           \x1b[0m│\x1b[41;30m        \x1b[0m│\x1b[41;30m This is known.              \x1b[0m│",
+		"│  20 │ Jon        │ Snow      │   2000 │ You know nothing, Jon Snow! │",
+		"│   1 │ Arya       │ Stark     │   3000 │                             │",
+		"│ 300 │\x1b[43;30m Tyrion     \x1b[0m│\x1b[43;30m Lannister \x1b[0m│\x1b[43;30m   5000 \x1b[0m│\x1b[43;30m                             \x1b[0m│",
+		"├─────┼────────────┼───────────┼────────┼─────────────────────────────┤",
+		"│     │            │ TOTAL     │  10000 │                             │",
+		"└─────┴────────────┴───────────┴────────┴─────────────────────────────┘",
+	}
+	expectedOut := strings.Join(expectedOutLines, "\n")
+	assert.Equal(t, expectedOut, tw.Render())
+
+	tw.SetStyle(StyleColoredBright)
+	tw.Style().Color.RowAlternate = tw.Style().Color.Row
+	expectedOutLines = []string{
+		"\x1b[106;30m   # \x1b[0m\x1b[106;30m FIRST NAME \x1b[0m\x1b[106;30m LAST NAME \x1b[0m\x1b[106;30m SALARY \x1b[0m\x1b[106;30m                             \x1b[0m",
+		"\x1b[106;30m   0 \x1b[0m\x1b[41;30m Winter     \x1b[0m\x1b[41;30m Is        \x1b[0m\x1b[41;30m      0 \x1b[0m\x1b[41;30m Coming.                     \x1b[0m",
+		"\x1b[106;30m     \x1b[0m\x1b[41;30m            \x1b[0m\x1b[41;30m           \x1b[0m\x1b[41;30m        \x1b[0m\x1b[41;30m The North Remembers!        \x1b[0m",
+		"\x1b[106;30m     \x1b[0m\x1b[41;30m            \x1b[0m\x1b[41;30m           \x1b[0m\x1b[41;30m        \x1b[0m\x1b[41;30m This is known.              \x1b[0m",
+		"\x1b[106;30m  20 \x1b[0m\x1b[107;30m Jon        \x1b[0m\x1b[107;30m Snow      \x1b[0m\x1b[107;30m   2000 \x1b[0m\x1b[107;30m You know nothing, Jon Snow! \x1b[0m",
+		"\x1b[106;30m   1 \x1b[0m\x1b[107;30m Arya       \x1b[0m\x1b[107;30m Stark     \x1b[0m\x1b[107;30m   3000 \x1b[0m\x1b[107;30m                             \x1b[0m",
+		"\x1b[106;30m 300 \x1b[0m\x1b[43;30m Tyrion     \x1b[0m\x1b[43;30m Lannister \x1b[0m\x1b[43;30m   5000 \x1b[0m\x1b[43;30m                             \x1b[0m",
+		"\x1b[46;30m     \x1b[0m\x1b[46;30m            \x1b[0m\x1b[46;30m TOTAL     \x1b[0m\x1b[46;30m  10000 \x1b[0m\x1b[46;30m                             \x1b[0m",
+	}
+	expectedOut = strings.Join(expectedOutLines, "\n")
+	assert.Equal(t, expectedOut, tw.Render())
+}
+
 func TestTable_Render_Sorted(t *testing.T) {
 	tw := NewWriter()
 	tw.AppendHeader(testHeader)

--- a/table/render_test.go
+++ b/table/render_test.go
@@ -879,11 +879,7 @@ func TestTable_Render_Reset(t *testing.T) {
 
 func TestTable_Render_RowPainter(t *testing.T) {
 	tw := NewWriter()
-	tw.AppendHeader(testHeader)
-	tw.AppendRows(testRows)
-	tw.AppendRow(testRowMultiLine)
-	tw.AppendFooter(testFooter)
-	tw.SetIndexColumn(1)
+
 	tw.SetRowPainter(func(row Row) text.Colors {
 		if salary, ok := row[3].(int); ok {
 			if salary > 3000 {
@@ -894,49 +890,13 @@ func TestTable_Render_RowPainter(t *testing.T) {
 		}
 		return nil
 	})
-	tw.SetStyle(StyleLight)
-	tw.SortBy([]SortBy{{Name: "Salary", Mode: AscNumeric}})
 
-	expectedOutLines := []string{
-		"┌─────┬────────────┬───────────┬────────┬─────────────────────────────┐",
-		"│   # │ FIRST NAME │ LAST NAME │ SALARY │                             │",
-		"├─────┼────────────┼───────────┼────────┼─────────────────────────────┤",
-		"│   0 │\x1b[41;30m Winter     \x1b[0m│\x1b[41;30m Is        \x1b[0m│\x1b[41;30m      0 \x1b[0m│\x1b[41;30m Coming.                     \x1b[0m│",
-		"│     │\x1b[41;30m            \x1b[0m│\x1b[41;30m           \x1b[0m│\x1b[41;30m        \x1b[0m│\x1b[41;30m The North Remembers!        \x1b[0m│",
-		"│     │\x1b[41;30m            \x1b[0m│\x1b[41;30m           \x1b[0m│\x1b[41;30m        \x1b[0m│\x1b[41;30m This is known.              \x1b[0m│",
-		"│  20 │ Jon        │ Snow      │   2000 │ You know nothing, Jon Snow! │",
-		"│   1 │ Arya       │ Stark     │   3000 │                             │",
-		"│ 300 │\x1b[43;30m Tyrion     \x1b[0m│\x1b[43;30m Lannister \x1b[0m│\x1b[43;30m   5000 \x1b[0m│\x1b[43;30m                             \x1b[0m│",
-		"├─────┼────────────┼───────────┼────────┼─────────────────────────────┤",
-		"│     │            │ TOTAL     │  10000 │                             │",
-		"└─────┴────────────┴───────────┴────────┴─────────────────────────────┘",
-	}
-	expectedOut := strings.Join(expectedOutLines, "\n")
-	assert.Equal(t, expectedOut, tw.Render())
-
-	tw.SetStyle(StyleColoredBright)
-	tw.Style().Color.RowAlternate = tw.Style().Color.Row
-	expectedOutLines = []string{
-		"\x1b[106;30m   # \x1b[0m\x1b[106;30m FIRST NAME \x1b[0m\x1b[106;30m LAST NAME \x1b[0m\x1b[106;30m SALARY \x1b[0m\x1b[106;30m                             \x1b[0m",
-		"\x1b[106;30m   0 \x1b[0m\x1b[41;30m Winter     \x1b[0m\x1b[41;30m Is        \x1b[0m\x1b[41;30m      0 \x1b[0m\x1b[41;30m Coming.                     \x1b[0m",
-		"\x1b[106;30m     \x1b[0m\x1b[41;30m            \x1b[0m\x1b[41;30m           \x1b[0m\x1b[41;30m        \x1b[0m\x1b[41;30m The North Remembers!        \x1b[0m",
-		"\x1b[106;30m     \x1b[0m\x1b[41;30m            \x1b[0m\x1b[41;30m           \x1b[0m\x1b[41;30m        \x1b[0m\x1b[41;30m This is known.              \x1b[0m",
-		"\x1b[106;30m  20 \x1b[0m\x1b[107;30m Jon        \x1b[0m\x1b[107;30m Snow      \x1b[0m\x1b[107;30m   2000 \x1b[0m\x1b[107;30m You know nothing, Jon Snow! \x1b[0m",
-		"\x1b[106;30m   1 \x1b[0m\x1b[107;30m Arya       \x1b[0m\x1b[107;30m Stark     \x1b[0m\x1b[107;30m   3000 \x1b[0m\x1b[107;30m                             \x1b[0m",
-		"\x1b[106;30m 300 \x1b[0m\x1b[43;30m Tyrion     \x1b[0m\x1b[43;30m Lannister \x1b[0m\x1b[43;30m   5000 \x1b[0m\x1b[43;30m                             \x1b[0m",
-		"\x1b[46;30m     \x1b[0m\x1b[46;30m            \x1b[0m\x1b[46;30m TOTAL     \x1b[0m\x1b[46;30m  10000 \x1b[0m\x1b[46;30m                             \x1b[0m",
-	}
-	expectedOut = strings.Join(expectedOutLines, "\n")
-	assert.Equal(t, expectedOut, tw.Render())
+	RunTestTable_Render_WithRowPainter(t, tw)
 }
 
 func TestTable_Render_IndexedRowPainter(t *testing.T) {
 	tw := NewWriter()
-	tw.AppendHeader(testHeader)
-	tw.AppendRows(testRows)
-	tw.AppendRow(testRowMultiLine)
-	tw.AppendFooter(testFooter)
-	tw.SetIndexColumn(1)
+
 	tw.SetIndexedRowPainter(func(idx int) text.Colors {
 		if idx > -1 {
 			if idx == 3 {
@@ -947,6 +907,16 @@ func TestTable_Render_IndexedRowPainter(t *testing.T) {
 		}
 		return nil
 	})
+
+	RunTestTable_Render_WithRowPainter(t, tw)
+}
+
+func RunTestTable_Render_WithRowPainter(t *testing.T, tw Writer) {
+	tw.AppendHeader(testHeader)
+	tw.AppendRows(testRows)
+	tw.AppendRow(testRowMultiLine)
+	tw.AppendFooter(testFooter)
+	tw.SetIndexColumn(1)
 	tw.SetStyle(StyleLight)
 	tw.SortBy([]SortBy{{Name: "Salary", Mode: AscNumeric}})
 

--- a/table/render_test.go
+++ b/table/render_test.go
@@ -884,7 +884,7 @@ func TestTable_Render_RowPainter(t *testing.T) {
 	tw.AppendRow(testRowMultiLine)
 	tw.AppendFooter(testFooter)
 	tw.SetIndexColumn(1)
-	tw.SetRowPainter(func(row Row, idx int) text.Colors {
+	tw.SetRowPainter(func(row Row) text.Colors {
 		if salary, ok := row[3].(int); ok {
 			if salary > 3000 {
 				return text.Colors{text.BgYellow, text.FgBlack}

--- a/table/sort.go
+++ b/table/sort.go
@@ -55,6 +55,10 @@ type rowsSorter struct {
 	sortedIndices []int
 }
 
+func (t *Table) SortedIndices() []int {
+	return t.sortedRowIndices
+}
+
 // getSortedRowIndices sorts and returns the row indices in Sorted order as
 // directed by Table.sortBy which can be set using Table.SortBy(...)
 func (t *Table) getSortedRowIndices() []int {

--- a/table/sort.go
+++ b/table/sort.go
@@ -75,6 +75,8 @@ func (t *Table) getSortedRowIndices() []int {
 		})
 	}
 
+	t.sortedRowIndices = sortedIndices
+
 	return sortedIndices
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -99,7 +99,7 @@ type Table struct {
 	// rowPainter is a custom function that given a Row, returns the colors to
 	// use on the entire row
 	rowPainter RowPainter
-	// rowPainter is a custom function that given a Row, returns the colors to
+	// indexedRowPainter is a custom function that given a row index, returns the colors to
 	// use on the entire row
 	indexedRowPainter IndexedRowPainter
 	// rowSeparator is a dummy row that contains the separator columns (dashes

--- a/table/table.go
+++ b/table/table.go
@@ -24,7 +24,7 @@ func (r Row) findColumnNumber(colName string) int {
 
 // RowPainter is a custom function that takes a Row as input and returns the
 // text.Colors{} to use on the entire row
-type RowPainter func(row Row) text.Colors
+type RowPainter func(row Row, idx int) text.Colors
 
 // rowStr defines a single row in the Table comprised of just string objects.
 type rowStr []string

--- a/table/table.go
+++ b/table/table.go
@@ -110,6 +110,8 @@ type Table struct {
 	separators map[int]bool
 	// sortBy stores a map of Column
 	sortBy []SortBy
+	// sortedRowIndices contains the sorted row indices for later reference
+	sortedRowIndices []int
 	// style contains all the strings used to draw the table, and more
 	style *Style
 	// suppressEmptyColumns hides columns which have no content on all regular

--- a/table/writer.go
+++ b/table/writer.go
@@ -28,6 +28,7 @@ type Writer interface {
 	SetIndexColumn(colNum int)
 	SetOutputMirror(mirror io.Writer)
 	SetRowPainter(painter RowPainter)
+	SetIndexedRowPainter(painter IndexedRowPainter)
 	SetStyle(style Style)
 	SetTitle(format string, a ...interface{})
 	SortBy(sortBy []SortBy)

--- a/table/writer.go
+++ b/table/writer.go
@@ -13,6 +13,7 @@ type Writer interface {
 	AppendSeparator()
 	ImportGrid(grid interface{}) bool
 	Length() int
+	SortedIndices() []int
 	Pager(opts ...PagerOption) Pager
 	Render() string
 	RenderCSV() string


### PR DESCRIPTION
## Proposed Changes
  - Add a new 'indexed row painter' which allows for painting the rows by index as well as value
  - Expose the 'sorted indices' on the table writer so that this can be used by a consumer to determine the final order of the table after sorting

### Background
I am using this project to build a cli, one of the operations involves selecting a value from the table using arrow keys. Allowing painting of the rows by index makes this far easier, especially when sorting is involved.
