### PR TITLE
OSC 8 hiperlink support

### DIFF
--- a/text/escape_seq_parser.go
+++ b/text/escape_seq_parser.go
@@ -78,6 +78,16 @@ func (s *escSeqParser) Consume(char rune) {
 	if s.inEscSeq {
 		s.escapeSeq += string(char)
 
+		// --- FIX for OSC 8 hyperlinks (e.g. \x1b]8;;url\x07label\x1b]8;;\x07)
+		if s.escSeqKind == escSeqKindOSI &&
+			strings.HasPrefix(s.escapeSeq, escapeStartConcealOSI) &&
+			char == '\a' { // BEL
+
+			s.ParseSeq(s.escapeSeq, s.escSeqKind)
+			s.Reset()
+			return
+		}
+
 		if s.isEscapeStopRune(char) {
 			s.ParseSeq(s.escapeSeq, s.escSeqKind)
 			s.Reset()


### PR DESCRIPTION
Fix handling of OSC 8 hyperlinks (e.g., \x1b]8;;url\x07label\x1b]8;;\x07) in escSeqParser.Consume

Add support for BEL (\x07)-terminated OSC sequences, which are used in hyperlinks (instead of the typical ESC \)

Ensures that escape sequences are correctly parsed and excluded from visible text width calculations
