### PR TITLE
Experimental Style funcs for progress

### DIFF
--- a/cmd/demo-progress/demo.go
+++ b/cmd/demo-progress/demo.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/progress"
@@ -144,6 +145,34 @@ func main() {
 	pw.Style().Visibility.TrackerOverall = !*flagHideOverallTracker
 	pw.Style().Visibility.Value = !*flagHideValue
 	pw.Style().Visibility.Pinned = *flagShowPinned
+
+	colors := []text.Colors{
+		{text.FgRed},
+		{text.FgGreen},
+		{text.FgYellow},
+		{text.FgBlue},
+		{text.FgMagenta},
+		{text.FgCyan},
+	}
+
+	pw.Style().CustomFuncs.TrackerDeterminate = func(value int64, total int64, maxLen int) string {
+		v := float64(value) / float64(total)
+		b := &strings.Builder{}
+		fmt.Fprintf(b, "[")
+		inner := maxLen - 2
+		for i := 0; i < inner; i++ {
+			delta := float64(i) / float64(inner)
+			colorIdx := delta * float64(len(colors))
+			color := colors[int(colorIdx)%len(colors)]
+			if delta < v {
+				fmt.Fprintf(b, "%s", color.Sprint("█"))
+			} else {
+				fmt.Fprintf(b, " ")
+			}
+		}
+		fmt.Fprintf(b, "]")
+		return b.String()
+	}
 
 	// call Render() in async mode; yes we don't have any trackers at the moment
 	go pw.Render()

--- a/progress/render.go
+++ b/progress/render.go
@@ -107,8 +107,8 @@ func (p *Progress) generateTrackerStr(t *Tracker, maxLen int, hint renderHint) s
 // generateTrackerStrDeterminate generates the tracker string for the case where
 // the Total value is known, and the progress percentage can be calculated.
 func (p *Progress) generateTrackerStrDeterminate(value int64, total int64, maxLen int) string {
-	if p.style.CustomFuncs.TrackerDeterminate != nil {
-		return p.style.CustomFuncs.TrackerDeterminate(value, total, maxLen)
+	if p.style.Renderer.TrackerDeterminate != nil {
+		return p.style.Renderer.TrackerDeterminate(value, total, maxLen)
 	}
 
 	pFinishedDots, pFinishedDotsFraction := 0.0, 0.0
@@ -137,7 +137,7 @@ func (p *Progress) generateTrackerStrDeterminate(value int64, total int64, maxLe
 	if pFinishedStrLen < maxLen {
 		pUnfinished = strings.Repeat(p.style.Chars.Unfinished, maxLen-pFinishedStrLen)
 	}
-	
+
 	return p.style.Colors.Tracker.Sprintf("%s%s%s%s%s",
 		p.style.Chars.BoxLeft, pFinished, pInProgress, pUnfinished, p.style.Chars.BoxRight,
 	)

--- a/progress/render.go
+++ b/progress/render.go
@@ -107,6 +107,10 @@ func (p *Progress) generateTrackerStr(t *Tracker, maxLen int, hint renderHint) s
 // generateTrackerStrDeterminate generates the tracker string for the case where
 // the Total value is known, and the progress percentage can be calculated.
 func (p *Progress) generateTrackerStrDeterminate(value int64, total int64, maxLen int) string {
+	if p.style.CustomFuncs.TrackerDeterminate != nil {
+		return p.style.CustomFuncs.TrackerDeterminate(value, total, maxLen)
+	}
+
 	pFinishedDots, pFinishedDotsFraction := 0.0, 0.0
 	pDotValue := float64(total) / float64(maxLen)
 	if pDotValue > 0 {
@@ -133,13 +137,13 @@ func (p *Progress) generateTrackerStrDeterminate(value int64, total int64, maxLe
 	if pFinishedStrLen < maxLen {
 		pUnfinished = strings.Repeat(p.style.Chars.Unfinished, maxLen-pFinishedStrLen)
 	}
-
+	
 	return p.style.Colors.Tracker.Sprintf("%s%s%s%s%s",
 		p.style.Chars.BoxLeft, pFinished, pInProgress, pUnfinished, p.style.Chars.BoxRight,
 	)
 }
 
-// generateTrackerStrDeterminate generates the tracker string for the case where
+// generateTrackerStrIndeterminate generates the tracker string for the case where
 // the Total value is unknown, and the progress percentage cannot be calculated.
 func (p *Progress) generateTrackerStrIndeterminate(maxLen int) string {
 	indicator := p.style.Chars.Indeterminate(maxLen)

--- a/progress/render.go
+++ b/progress/render.go
@@ -146,6 +146,10 @@ func (p *Progress) generateTrackerStrDeterminate(value int64, total int64, maxLe
 // generateTrackerStrIndeterminate generates the tracker string for the case where
 // the Total value is unknown, and the progress percentage cannot be calculated.
 func (p *Progress) generateTrackerStrIndeterminate(maxLen int) string {
+	if p.style.Renderer.TrackerIndeterminate != nil {
+		return p.style.Renderer.TrackerIndeterminate(maxLen)
+	}
+
 	indicator := p.style.Chars.Indeterminate(maxLen)
 
 	pUnfinished := ""

--- a/progress/render_test.go
+++ b/progress/render_test.go
@@ -938,3 +938,50 @@ func TestProgress_RenderSomeTrackers_WithPinnedMessages_MultiLines(t *testing.T)
 	}
 	showOutputOnFailure(t, out)
 }
+
+func TestProgress_RenderSomeTrackers_WithCustomTrackerDeterminate(t *testing.T) {
+	renderOutput := outputWriter{}
+
+	pw := generateWriter()
+	pw.SetOutputWriter(&renderOutput)
+	pw.SetTrackerPosition(PositionRight)
+
+	symbols := []string{"♠", "♥", "♦", "♣", "🂡", "🂱"}
+
+	pw.Style().Renderer.TrackerDeterminate = func(value int64, total int64, maxLen int) string {
+		v := float64(value) / float64(total)
+		b := &strings.Builder{}
+		fmt.Fprintf(b, "[")
+		inner := maxLen - 2
+		for i := 0; i < inner; i++ {
+			delta := float64(i) / float64(inner)
+			symbolIdx := int(delta * float64(len(symbols)))
+			if symbolIdx >= len(symbols) {
+				symbolIdx = len(symbols) - 1
+			}
+			if delta < v {
+				fmt.Fprintf(b, "%s", symbols[symbolIdx])
+			} else {
+				fmt.Fprintf(b, " ")
+			}
+		}
+		fmt.Fprintf(b, "]")
+		return b.String()
+	}
+
+	go trackSomething(pw, &Tracker{Message: "Custom Tracker #1", Total: 1000, Units: UnitsDefault})
+	go trackSomething(pw, &Tracker{Message: "Custom Tracker #2", Total: 1000, Units: UnitsBytes})
+	renderAndWait(pw, false)
+
+	expectedOutPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`Custom Tracker #1 \.\.\. done! \[\d+\.\d+K in [\d.]+ms]`),
+		regexp.MustCompile(`Custom Tracker #2 \.\.\. done! \[\d+\.\d+KB in [\d.]+ms]`),
+	}
+	out := renderOutput.String()
+	for _, expectedOutPattern := range expectedOutPatterns {
+		if !expectedOutPattern.MatchString(out) {
+			assert.Fail(t, "Failed to find a pattern in the Output.", expectedOutPattern.String())
+		}
+	}
+	showOutputOnFailure(t, out)
+}

--- a/progress/render_test.go
+++ b/progress/render_test.go
@@ -985,3 +985,40 @@ func TestProgress_RenderSomeTrackers_WithCustomTrackerDeterminate(t *testing.T) 
 	}
 	showOutputOnFailure(t, out)
 }
+
+func TestProgress_RenderSomeTrackers_WithCustomTrackerIndeterminate(t *testing.T) {
+	renderOutput := outputWriter{}
+
+	pw := generateWriter()
+	pw.SetOutputWriter(&renderOutput)
+	pw.SetTrackerPosition(PositionRight)
+
+	pw.Style().Renderer.TrackerIndeterminate = func(maxLen int) string {
+		b := &strings.Builder{}
+		fmt.Fprintf(b, "[")
+		inner := maxLen - 2
+		for i := 0; i < inner; i++ {
+			if i == 0 {
+				fmt.Fprintf(b, "★")
+			} else {
+				fmt.Fprintf(b, "☆")
+			}
+		}
+		fmt.Fprintf(b, "]")
+		return b.String()
+	}
+
+	go trackSomethingIndeterminate(pw, &Tracker{Message: "Indeterminate Tracker", Total: 0, Units: UnitsDefault})
+	renderAndWait(pw, false)
+
+	expectedOutPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`Indeterminate Tracker \.\.\. done! \[\d+ in [\d.]+ms]`),
+	}
+	out := renderOutput.String()
+	for _, expectedOutPattern := range expectedOutPatterns {
+		if !expectedOutPattern.MatchString(out) {
+			assert.Fail(t, "Failed to find a pattern in the Output.", expectedOutPattern.String())
+		}
+	}
+	showOutputOnFailure(t, out)
+}

--- a/progress/style.go
+++ b/progress/style.go
@@ -223,4 +223,9 @@ type StyleRenderer struct {
 	// maxLen is the number of characters available for the progress bar.
 	// return the complete progress bar string. E.g. [===----]
 	TrackerDeterminate func(value int64, total int64, maxLen int) string
+
+	// TrackerIndeterminate will override how the indeterminate progress bar is rendered.
+	// maxLen is the number of characters available for the progress bar.
+	// return the complete progress bar string. E.g. [<#>----]
+	TrackerIndeterminate func(maxLen int) string
 }

--- a/progress/style.go
+++ b/progress/style.go
@@ -8,12 +8,12 @@ import (
 
 // Style declares how to render the Progress/Trackers.
 type Style struct {
-	Name        string          // name of the Style
-	Chars       StyleChars      // characters to use on the progress bar
-	Colors      StyleColors     // colors to use on the progress bar
-	Options     StyleOptions    // misc. options for the progress bar
-	Visibility  StyleVisibility // show/hide components of the progress bar(s)
-	CustomFuncs StyleFunctions  // custom render functions for the progress bar
+	Name       string          // name of the Style
+	Chars      StyleChars      // characters to use on the progress bar
+	Colors     StyleColors     // colors to use on the progress bar
+	Options    StyleOptions    // misc. options for the progress bar
+	Visibility StyleVisibility // show/hide components of the progress bar(s)
+	Renderer   StyleRenderer   // custom render functions for the progress bar
 }
 
 var (
@@ -217,6 +217,10 @@ var StyleVisibilityDefault = StyleVisibility{
 	Value:          true,
 }
 
-type StyleFunctions struct {
+type StyleRenderer struct {
+	// TrackerDeterminate will override how the progress bar is rendered.
+	// value is the current value of the tracker out of total.
+	// maxLen is the number of characters available for the progress bar.
+	// return the complete progress bar string. E.g. [===----]
 	TrackerDeterminate func(value int64, total int64, maxLen int) string
 }

--- a/progress/style.go
+++ b/progress/style.go
@@ -8,11 +8,12 @@ import (
 
 // Style declares how to render the Progress/Trackers.
 type Style struct {
-	Name       string          // name of the Style
-	Chars      StyleChars      // characters to use on the progress bar
-	Colors     StyleColors     // colors to use on the progress bar
-	Options    StyleOptions    // misc. options for the progress bar
-	Visibility StyleVisibility // show/hide components of the progress bar(s)
+	Name        string          // name of the Style
+	Chars       StyleChars      // characters to use on the progress bar
+	Colors      StyleColors     // colors to use on the progress bar
+	Options     StyleOptions    // misc. options for the progress bar
+	Visibility  StyleVisibility // show/hide components of the progress bar(s)
+	CustomFuncs StyleFunctions  // custom render functions for the progress bar
 }
 
 var (
@@ -214,4 +215,8 @@ var StyleVisibilityDefault = StyleVisibility{
 	Tracker:        true,
 	TrackerOverall: false,
 	Value:          true,
+}
+
+type StyleFunctions struct {
+	TrackerDeterminate func(value int64, total int64, maxLen int) string
 }


### PR DESCRIPTION
This is an idea for extending the progress package with fully custom rendering functions.

In this PR it's only implemented for a single part of the rendering, just enough to illustrate the idea.

<a href="https://asciinema.org/a/oYnNpwwInpL7kF4vkUAGhOKQQ" target="_blank"><img src="https://asciinema.org/a/oYnNpwwInpL7kF4vkUAGhOKQQ.svg" /></a>

Or with a 24 bit color terminal, you could do something like this:
<a href="https://asciinema.org/a/IVZ28XQG7uJSTOqAUsTqHlpqV" target="_blank"><img src="https://asciinema.org/a/IVZ28XQG7uJSTOqAUsTqHlpqV.svg" /></a>
