### PR TITLE
Only adjust terminal size when the output writer is stdout

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -346,14 +346,13 @@ func (p *Progress) initForRender() {
 	// if not output write has been set, output to STDOUT
 	if p.outputWriter == nil {
 		p.outputWriter = os.Stdout
-		// pick a sane update frequency if none set
-		if p.updateFrequency <= 0 {
-			p.updateFrequency = DefaultUpdateFrequency
-		}
-
 		// get the current terminal size for preventing roll-overs, and do this in a
 		// background loop until end of render
 		go p.watchTerminalSize() // needs p.updateFrequency
+	}
+	// pick a sane update frequency if none set
+	if p.updateFrequency <= 0 {
+		p.updateFrequency = DefaultUpdateFrequency
 	}
 
 }

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -346,16 +346,16 @@ func (p *Progress) initForRender() {
 	// if not output write has been set, output to STDOUT
 	if p.outputWriter == nil {
 		p.outputWriter = os.Stdout
+		// pick a sane update frequency if none set
+		if p.updateFrequency <= 0 {
+			p.updateFrequency = DefaultUpdateFrequency
+		}
+
+		// get the current terminal size for preventing roll-overs, and do this in a
+		// background loop until end of render
+		go p.watchTerminalSize() // needs p.updateFrequency
 	}
 
-	// pick a sane update frequency if none set
-	if p.updateFrequency <= 0 {
-		p.updateFrequency = DefaultUpdateFrequency
-	}
-
-	// get the current terminal size for preventing roll-overs, and do this in a
-	// background loop until end of render
-	go p.watchTerminalSize() // needs p.updateFrequency
 }
 
 func (p *Progress) updateTerminalSize() {

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -346,15 +346,18 @@ func (p *Progress) initForRender() {
 	// if not output write has been set, output to STDOUT
 	if p.outputWriter == nil {
 		p.outputWriter = os.Stdout
-		// get the current terminal size for preventing roll-overs, and do this in a
-		// background loop until end of render
-		go p.watchTerminalSize() // needs p.updateFrequency
 	}
+
 	// pick a sane update frequency if none set
 	if p.updateFrequency <= 0 {
 		p.updateFrequency = DefaultUpdateFrequency
 	}
 
+	if p.outputWriter == os.Stdout {
+		// get the current terminal size for preventing roll-overs, and do this in a
+		// background loop until end of render. This only works if the output writer is STDOUT.
+		go p.watchTerminalSize() // needs p.updateFrequency
+	}
 }
 
 func (p *Progress) updateTerminalSize() {


### PR DESCRIPTION
The logic adjusting the rendering based on terminal size assumes the output is stdout. This is only makes sense when the output is stdout.

## Proposed Changes
  - this PR move the goroutine `p.watchTerminalSize()` so it's only called when p.outputWriter is set to os.Stdout

