### PR TITLE
progress: Fix some race conditions for Render/Stop and trackers.

### DIFF
--- a/progress/render_test.go
+++ b/progress/render_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,13 +20,18 @@ var (
 
 type outputWriter struct {
 	Text strings.Builder
+	m    sync.Mutex
 }
 
 func (w *outputWriter) Write(p []byte) (n int, err error) {
+	w.m.Lock()
+	defer w.m.Unlock()
 	return w.Text.Write(p)
 }
 
 func (w *outputWriter) String() string {
+	w.m.Lock()
+	defer w.m.Unlock()
 	return w.Text.String()
 }
 

--- a/progress/writer.go
+++ b/progress/writer.go
@@ -49,5 +49,7 @@ type Writer interface {
 
 // NewWriter initializes and returns a Writer.
 func NewWriter() Writer {
-	return &Progress{}
+	p := &Progress{}
+	p.wg.Add(1) // Opposite: p.Render()
+	return p
 }


### PR DESCRIPTION
## Proposed Changes
  - Add an internal `WaitGroup` for progress operations.
  - Add counters to the WaitGroup on:
    * `NewWriter` creation (top-level counter)
    * `beginRender()`
 - Decrement counters (`wg.Done()` upon:
    * `endRender()` -- Called after `RenderContextCancelFunc()` causes the main loop to begin closing. 
    * End of `Render()`  -- For top-level counter
- `wg.Wait()` within `Stop()`, to block & assert that all routines have finished before returning.
- Add mutexes to protect access of `tracker.startTime` vars.
- Add lightweight mutex to `outputWriter` struct used in tests.

I'm sure there are other solutions, but after playing with it some, this is the only way I could find to assert that all "write" operations taking place within `Render()` are wrapped-up before `Stop()` is allowed to conclude & return.   
The current Mutex-only approach (e.g.: `p.renderContextCancelMutex.Lock()` protects the _individual_ write-operations from occurring simultaneously, but AFAICT, there was no locking to ensure that the rendering chain was finished before `Stop()` was allowed to return.

In the tests, the race condition was particularly apparent within `TestProgress_RenderNeverStarted`:
```
func TestProgress_RenderNeverStarted(t *testing.T) {
	renderOutput := strings.Builder{}

	pw := generateWriter()
	pw.SetOutputWriter(&renderOutput)

	tr := &Tracker{DeferStart: true}
	pw.AppendTracker(tr)

	go pw.Render()
	time.Sleep(renderWaitTime)
	tr.MarkAsDone()
	pw.Stop()
	time.Sleep(renderWaitTime)

	expectedOutPatterns := []*regexp.Regexp{
		regexp.MustCompile(`\s*\.\.\. {2}\?\?\? {2}\[\.{23}] \[0 in 0s]`),
		regexp.MustCompile(`\s*\.\.\. done! \[0 in 0s]`),
	}
	out := renderOutput.String()
	for _, expectedOutPattern := range expectedOutPatterns {
		if !expectedOutPattern.MatchString(out) {
			assert.Fail(t, "Failed to find a pattern in the Output.", expectedOutPattern.String())
		}
	}
	showOutputOnFailure(t, out)
}
```

Here, even with `time.Sleep` calls, `renderOutput` could still be manipulated by the `go pw.Render()` routine while (and even *after*) `Stop()` and `endRender()` is running, without locking.
It's then subsequently accessed (`renderOutput.String()`), which might be indeterminate.

Fixes #399, as validated by this:
```
$> git rev-parse HEAD && go test -race
f3ad621bb66506f0f1342cddf692af24e4aaadcd
PASS
ok  	github.com/jedib0t/go-pretty/v6/progress	1.538s
```
