### PR TITLE
progress: fix speed decay on done trackers and log overwrite; fixes #405

### DIFF
--- a/progress/render.go
+++ b/progress/render.go
@@ -107,9 +107,52 @@ func (p *Progress) endRender() {
 	p.renderInProgress = false
 }
 
+// extractDoneAndActiveTrackers walks p.trackersActive and partitions it into
+// (stillActive, newlyDone). Used by the default scrollback render path; mirrors
+// the pre-v6.7.8 behavior where done trackers exit the rewindable region on
+// completion.
+func (p *Progress) extractDoneAndActiveTrackers() ([]*Tracker, []*Tracker) {
+	p.consumeQueuedTrackers()
+
+	var trackersActive, trackersNewlyDone []*Tracker
+	var activeTrackersProgress int64
+	var maxETA time.Duration
+
+	p.trackersDoneMutex.RLock()
+	lengthDone := len(p.trackersDone)
+	p.trackersDoneMutex.RUnlock()
+
+	p.trackersActiveMutex.RLock()
+	trackersActive = make([]*Tracker, 0, len(p.trackersActive))
+	trackersNewlyDone = make([]*Tracker, 0, len(p.trackersActive)/4)
+	for _, tracker := range p.trackersActive {
+		if !tracker.IsDone() {
+			trackersActive = append(trackersActive, tracker)
+			activeTrackersProgress += int64(tracker.PercentDone())
+			if eta := tracker.ETA(); eta > maxETA {
+				maxETA = eta
+			}
+		} else if !tracker.RemoveOnCompletion {
+			trackersNewlyDone = append(trackersNewlyDone, tracker)
+		}
+	}
+	p.trackersActiveMutex.RUnlock()
+	p.sortBy.Sort(trackersNewlyDone)
+	p.sortBy.Sort(trackersActive)
+
+	p.overallTracker.value = int64(lengthDone+len(trackersNewlyDone)) * 100
+	p.overallTracker.value += activeTrackersProgress
+	p.overallTracker.minETA = maxETA
+	if len(trackersActive) == 0 {
+		p.overallTracker.MarkAsDone()
+	}
+
+	return trackersActive, trackersNewlyDone
+}
+
 // extractAllTrackersInOrder extracts all trackers (both active and done) and
 // sorts them together when SortByIndex is used. This allows maintaining a fixed
-// order regardless of completion status.
+// order regardless of completion status. Used by the KeepTrackersTogether path.
 func (p *Progress) extractAllTrackersInOrder() []*Tracker {
 	// move trackers waiting in queue to the active list
 	p.consumeQueuedTrackers()
@@ -204,10 +247,11 @@ func (p *Progress) generateTrackerStrIndeterminate(maxLen int) string {
 }
 
 func (p *Progress) moveCursorToTheTop(out *strings.Builder) {
-	// Count all trackers that will be rendered (both done and active)
+	// Count trackers that occupy the rewindable region. In the default
+	// scrollback mode, that's just active trackers; with KeepTrackersTogether,
+	// done trackers are also re-rendered each tick.
 	var numTrackersToRender int
 
-	// Count active trackers (excluding those with RemoveOnCompletion)
 	p.trackersActiveMutex.RLock()
 	for _, tracker := range p.trackersActive {
 		if !tracker.RemoveOnCompletion {
@@ -216,14 +260,15 @@ func (p *Progress) moveCursorToTheTop(out *strings.Builder) {
 	}
 	p.trackersActiveMutex.RUnlock()
 
-	// Count done trackers (excluding those with RemoveOnCompletion)
-	p.trackersDoneMutex.RLock()
-	for _, tracker := range p.trackersDone {
-		if !tracker.RemoveOnCompletion {
-			numTrackersToRender++
+	if p.style.Options.KeepTrackersTogether {
+		p.trackersDoneMutex.RLock()
+		for _, tracker := range p.trackersDone {
+			if !tracker.RemoveOnCompletion {
+				numTrackersToRender++
+			}
 		}
+		p.trackersDoneMutex.RUnlock()
 	}
-	p.trackersDoneMutex.RUnlock()
 
 	numLinesToMoveUp := numTrackersToRender
 	if p.style.Visibility.TrackerOverall && p.overallTracker != nil && !p.overallTracker.IsDone() {
@@ -372,11 +417,13 @@ func (p *Progress) renderTrackers(lastRenderLength int) int {
 		p.moveCursorToTheTop(&out)
 	}
 
-	// flush logs above the rewindable region; moveCursorToTheTop does not count them
-	p.renderLogs(&out)
-
-	// render the trackers that are done, and then the ones that are active
-	p.renderTrackersDoneAndActive(&out, hint)
+	if p.style.Options.KeepTrackersTogether {
+		// flush logs above the rewindable region; moveCursorToTheTop does not count them
+		p.renderLogs(&out)
+		p.renderTrackersDoneAndActive(&out, hint)
+	} else {
+		p.renderTrackersScrollback(&out, hint)
+	}
 
 	// render the overall tracker
 	if p.style.Visibility.TrackerOverall {
@@ -399,6 +446,37 @@ func (p *Progress) renderTrackers(lastRenderLength int) int {
 	}
 
 	return out.Len()
+}
+
+// renderTrackersScrollback emits newly-done trackers and logs as one-shot
+// scrollback above the rewindable region (pinned + still-active). This is the
+// pre-v6.7.8 layout used when StyleOptions.KeepTrackersTogether is false.
+func (p *Progress) renderTrackersScrollback(out *strings.Builder, hint renderHint) {
+	trackersActive, trackersNewlyDone := p.extractDoneAndActiveTrackers()
+
+	// newly-done trackers -> scrollback
+	for _, tracker := range trackersNewlyDone {
+		p.renderTracker(out, tracker, hint)
+	}
+	p.trackersDoneMutex.Lock()
+	p.trackersDone = append(p.trackersDone, trackersNewlyDone...)
+	p.trackersDoneMutex.Unlock()
+
+	// logs -> scrollback, between newly-done and the rewindable region
+	p.renderLogs(out)
+
+	// pinned (part of rewindable region)
+	if len(trackersActive) > 0 && p.style.Visibility.Pinned {
+		p.renderPinnedMessages(out, hint)
+	}
+
+	// active trackers (part of rewindable region)
+	for _, tracker := range trackersActive {
+		p.renderTracker(out, tracker, hint)
+	}
+	p.trackersActiveMutex.Lock()
+	p.trackersActive = trackersActive
+	p.trackersActiveMutex.Unlock()
 }
 
 func (p *Progress) renderTrackersDoneAndActive(out *strings.Builder, hint renderHint) {

--- a/progress/render.go
+++ b/progress/render.go
@@ -372,6 +372,9 @@ func (p *Progress) renderTrackers(lastRenderLength int) int {
 		p.moveCursorToTheTop(&out)
 	}
 
+	// flush logs above the rewindable region; moveCursorToTheTop does not count them
+	p.renderLogs(&out)
+
 	// render the trackers that are done, and then the ones that are active
 	p.renderTrackersDoneAndActive(&out, hint)
 
@@ -431,20 +434,21 @@ func (p *Progress) renderTrackersDoneAndActive(out *strings.Builder, hint render
 	p.trackersActive = trackersActive
 	p.trackersActiveMutex.Unlock()
 
-	// render all the logs received and flush them out
+	// render pinned messages
+	if len(trackersActive) > 0 && p.style.Visibility.Pinned {
+		p.renderPinnedMessages(out, hint)
+	}
+}
+
+func (p *Progress) renderLogs(out *strings.Builder) {
 	p.logsToRenderMutex.Lock()
+	defer p.logsToRenderMutex.Unlock()
 	for _, log := range p.logsToRender {
 		out.WriteString(text.EraseLine.Sprint())
 		out.WriteString(log)
 		out.WriteRune('\n')
 	}
 	p.logsToRender = nil
-	p.logsToRenderMutex.Unlock()
-
-	// render pinned messages
-	if len(trackersActive) > 0 && p.style.Visibility.Pinned {
-		p.renderPinnedMessages(out, hint)
-	}
 }
 
 func (p *Progress) renderTrackerStats(out *strings.Builder, t *Tracker, hint renderHint) {
@@ -515,9 +519,14 @@ func (p *Progress) renderTrackerStatsSpeed(out *strings.Builder, t *Tracker, hin
 			p.renderTrackerStatsSpeedInternal(out, p.style.Options.SpeedOverallFormatter(int64(speed)))
 		}
 	} else {
-		timeStart := t.timeStartValue()
+		timeStart, timeStop, done := t.timeStartStopAndDone()
 		if !timeStart.IsZero() {
-			timeTaken := time.Since(timeStart)
+			var timeTaken time.Duration
+			if done {
+				timeTaken = timeStop.Sub(timeStart)
+			} else {
+				timeTaken = time.Since(timeStart)
+			}
 			if timeTakenRounded := timeTaken.Round(speedPrecision); timeTakenRounded > speedPrecision {
 				p.renderTrackerStatsSpeedInternal(out, t.Units.Sprint(int64(float64(t.Value())/timeTakenRounded.Seconds())))
 			}
@@ -538,9 +547,9 @@ func (p *Progress) renderTrackerStatsSpeedInternal(out *strings.Builder, speed s
 
 func (p *Progress) renderTrackerStatsTime(outStats *strings.Builder, t *Tracker, hint renderHint) {
 	var td, tp time.Duration
-	timeStart, timeStop := t.timeStartAndStop()
+	timeStart, timeStop, done := t.timeStartStopAndDone()
 	if !timeStart.IsZero() {
-		if t.IsDone() {
+		if done {
 			td = timeStop.Sub(timeStart)
 		} else {
 			td = time.Since(timeStart)
@@ -548,7 +557,7 @@ func (p *Progress) renderTrackerStatsTime(outStats *strings.Builder, t *Tracker,
 	}
 	if hint.isOverallTracker {
 		tp = p.style.Options.TimeOverallPrecision
-	} else if t.IsDone() {
+	} else if done {
 		tp = p.style.Options.TimeDonePrecision
 	} else {
 		tp = p.style.Options.TimeInProgressPrecision

--- a/progress/render_test.go
+++ b/progress/render_test.go
@@ -1138,3 +1138,47 @@ func TestProgress_RenderWithSortByIndex_MixedIndexedAndUnindexed(t *testing.T) {
 
 	showOutputOnFailure(t, out)
 }
+
+func TestProgress_renderTrackerStatsSpeed_DoneTrackerStable(t *testing.T) {
+	pw := &Progress{}
+	pw.Style().Visibility.Speed = true
+
+	tracker := &Tracker{Total: 100, Units: UnitsDefault}
+	tracker.mutex.Lock()
+	tracker.timeStart = time.Now().Add(-2 * time.Second)
+	tracker.timeStop = time.Now().Add(-1 * time.Second)
+	tracker.value = 100
+	tracker.done = true
+	tracker.mutex.Unlock()
+
+	var out1, out2 strings.Builder
+	pw.renderTrackerStatsSpeed(&out1, tracker, renderHint{})
+	time.Sleep(50 * time.Millisecond)
+	pw.renderTrackerStatsSpeed(&out2, tracker, renderHint{})
+
+	assert.NotEmpty(t, out1.String(), "expected non-empty speed output for a done tracker")
+	assert.Equal(t, out1.String(), out2.String(),
+		"speed display for a done tracker must not change between renders")
+}
+
+func TestProgress_renderTrackers_LogsAppearAboveTrackers(t *testing.T) {
+	renderOutput := outputWriter{}
+	pw := generateWriter()
+	pw.SetOutputWriter(&renderOutput)
+
+	pw.Log("log-message-marker")
+	tracker := &Tracker{Message: "tracker-message-marker", Total: 100, Units: UnitsDefault}
+	go trackSomething(pw, tracker)
+	renderAndWait(pw, false)
+
+	out := renderOutput.String()
+	logPos := strings.Index(out, "log-message-marker")
+	trackerPos := strings.Index(out, "tracker-message-marker")
+
+	assert.Greater(t, logPos, -1, "log message should appear in output")
+	assert.Greater(t, trackerPos, -1, "tracker message should appear in output")
+	assert.Less(t, logPos, trackerPos,
+		"log must be rendered above the tracker block so subsequent ticks don't overwrite it")
+
+	showOutputOnFailure(t, out)
+}

--- a/progress/render_test.go
+++ b/progress/render_test.go
@@ -1161,24 +1161,75 @@ func TestProgress_renderTrackerStatsSpeed_DoneTrackerStable(t *testing.T) {
 		"speed display for a done tracker must not change between renders")
 }
 
-func TestProgress_renderTrackers_LogsAppearAboveTrackers(t *testing.T) {
-	renderOutput := outputWriter{}
+// Default (StyleOptions.KeepTrackersTogether=false) preserves the pre-v6.7.8
+// scrollback layout: newly-done -> log -> active.
+func TestProgress_renderTrackers_DefaultMode_LogsBetweenNewlyDoneAndActive(t *testing.T) {
+	out := &outputWriter{}
 	pw := generateWriter()
-	pw.SetOutputWriter(&renderOutput)
+	pw.SetOutputWriter(out)
 
-	pw.Log("log-message-marker")
-	tracker := &Tracker{Message: "tracker-message-marker", Total: 100, Units: UnitsDefault}
-	go trackSomething(pw, tracker)
-	renderAndWait(pw, false)
+	newlyDone := &Tracker{Message: "NEWLY-DONE-MARKER", Total: 100, Units: UnitsDefault}
+	pw.AppendTracker(newlyDone)
+	newlyDone.Increment(100)
 
-	out := renderOutput.String()
-	logPos := strings.Index(out, "log-message-marker")
-	trackerPos := strings.Index(out, "tracker-message-marker")
+	active := &Tracker{Message: "ACTIVE-MARKER", Total: 100, Units: UnitsDefault}
+	pw.AppendTracker(active)
+	active.Increment(50)
 
-	assert.Greater(t, logPos, -1, "log message should appear in output")
-	assert.Greater(t, trackerPos, -1, "tracker message should appear in output")
-	assert.Less(t, logPos, trackerPos,
-		"log must be rendered above the tracker block so subsequent ticks don't overwrite it")
+	pw.Log("LOG-MARKER")
 
-	showOutputOnFailure(t, out)
+	pwImpl := pw.(*Progress)
+	pwImpl.initForRender()
+	pwImpl.renderTrackers(0)
+
+	output := out.String()
+	newlyDonePos := strings.Index(output, "NEWLY-DONE-MARKER")
+	logPos := strings.Index(output, "LOG-MARKER")
+	activePos := strings.Index(output, "ACTIVE-MARKER")
+
+	assert.Greater(t, newlyDonePos, -1, "newly-done tracker must appear")
+	assert.Greater(t, logPos, -1, "log must appear")
+	assert.Greater(t, activePos, -1, "active tracker must appear")
+
+	assert.Less(t, newlyDonePos, logPos, "newly-done must render above log")
+	assert.Less(t, logPos, activePos, "log must render above active tracker")
+
+	showOutputOnFailure(t, output)
+}
+
+// Opt-in (StyleOptions.KeepTrackersTogether=true) keeps the post-v6.7.8 layout
+// needed for SortByIndex to reorder done trackers: log -> done -> active.
+func TestProgress_renderTrackers_KeepTrackersTogetherMode_LogsAboveAll(t *testing.T) {
+	out := &outputWriter{}
+	pw := generateWriter()
+	pw.SetOutputWriter(out)
+	pw.Style().Options.KeepTrackersTogether = true
+
+	done := &Tracker{Message: "DONE-MARKER", Total: 100, Units: UnitsDefault}
+	pw.AppendTracker(done)
+	done.Increment(100)
+
+	active := &Tracker{Message: "ACTIVE-MARKER", Total: 100, Units: UnitsDefault}
+	pw.AppendTracker(active)
+	active.Increment(50)
+
+	pw.Log("LOG-MARKER")
+
+	pwImpl := pw.(*Progress)
+	pwImpl.initForRender()
+	pwImpl.renderTrackers(0)
+
+	output := out.String()
+	donePos := strings.Index(output, "DONE-MARKER")
+	logPos := strings.Index(output, "LOG-MARKER")
+	activePos := strings.Index(output, "ACTIVE-MARKER")
+
+	assert.Greater(t, donePos, -1, "done tracker must appear")
+	assert.Greater(t, logPos, -1, "log must appear")
+	assert.Greater(t, activePos, -1, "active tracker must appear")
+
+	assert.Less(t, logPos, donePos, "log must render above the entire rewindable region")
+	assert.Less(t, donePos, activePos, "done must render above active (default sort order)")
+
+	showOutputOnFailure(t, output)
 }

--- a/progress/style.go
+++ b/progress/style.go
@@ -156,6 +156,7 @@ type StyleOptions struct {
 	ErrorString             string         // "error!" string
 	ETAPrecision            time.Duration  // precision for ETA
 	ETAString               string         // string for ETA
+	KeepTrackersTogether    bool           // keep done and active trackers together in one repainted frame (needed for SortByIndex to reorder done trackers)
 	Separator               string         // text between message and tracker
 	SnipIndicator           string         // text denoting message snipping
 	PercentFormat           string         // formatting to use for percentage
@@ -176,6 +177,7 @@ var StyleOptionsDefault = StyleOptions{
 	ErrorString:             "fail!",
 	ETAPrecision:            time.Second,
 	ETAString:               "~ETA",
+	KeepTrackersTogether:    false,
 	PercentFormat:           "%5.2f%%",
 	PercentIndeterminate:    " ??? ",
 	Separator:               " ... ",

--- a/progress/tracker.go
+++ b/progress/tracker.go
@@ -265,13 +265,17 @@ func (t *Tracker) valueAndTotal() (int64, int64) {
 	return value, total
 }
 
-// timeStartAndStop returns the start and stop times safely.
-func (t *Tracker) timeStartAndStop() (time.Time, time.Time) {
+// timeStartStopAndDone returns timeStart, timeStop, and done under a single
+// RLock so callers see a consistent snapshot — needed because an active→done
+// transition between separate reads would yield a non-zero timeStart with a
+// zero timeStop while done is true, breaking timeStop.Sub(timeStart).
+func (t *Tracker) timeStartStopAndDone() (time.Time, time.Time, bool) {
 	t.mutex.RLock()
 	timeStart := t.timeStart
 	timeStop := t.timeStop
+	done := t.done
 	t.mutex.RUnlock()
-	return timeStart, timeStop
+	return timeStart, timeStop, done
 }
 
 // timeStartValue returns the start time safely.

--- a/progress/tracker_sort.go
+++ b/progress/tracker_sort.go
@@ -9,14 +9,16 @@ const (
 	// SortByNone doesn't do any sorting == sort by insertion order.
 	SortByNone SortBy = iota
 
-	// SortByIndex sorts by the Index field in ascending order. When this is used,
-	// trackers are rendered in Index order regardless of completion status (done
-	// and active trackers are merged and sorted together). Index 0 comes first.
+	// SortByIndex sorts by the Index field in ascending order. Index 0 comes
+	// first. To reorder done trackers as well, set
+	// StyleOptions.KeepTrackersTogether = true; otherwise done trackers stay
+	// frozen in completion order and only active trackers are sorted by Index.
 	SortByIndex
 
-	// SortByIndexDsc sorts by the Index field in descending order. When this is used,
-	// trackers are rendered in Index order regardless of completion status (done
-	// and active trackers are merged and sorted together). Higher indices come first.
+	// SortByIndexDsc sorts by the Index field in descending order. Higher
+	// indices come first. To reorder done trackers as well, set
+	// StyleOptions.KeepTrackersTogether = true; otherwise done trackers stay
+	// frozen in completion order and only active trackers are sorted by Index.
 	SortByIndexDsc
 
 	// SortByMessage sorts by the Message alphabetically in ascending order.


### PR DESCRIPTION
1. Per-tracker speed for a done tracker decayed toward zero on every subsequent render tick. Done trackers are now repainted each cycle (previously they were painted once at the active->done transition), but renderTrackerStatsSpeed still used time.Since(timeStart) as the denominator. Use timeStop-timeStart for done trackers, matching renderTrackerStatsTime.

2. Log messages were overwritten by a stale tracker render on the next tick. Logs were emitted between the tracker block and pinned messages but were not counted by moveCursorToTheTop, leaving the cursor rewind short by len(logs) lines so trackers re-painted on top of the log row. Emit logs above the rewindable region instead, so they sit as permanent scrollback (the pre-v6.7.8 layout).