### PR TITLE
fix: wrap wide runes when wrapLen is odd in WrapHard

### DIFF
--- a/text/wrap.go
+++ b/text/wrap.go
@@ -89,7 +89,7 @@ func WrapText(str string, wrapLen int) string {
 func appendChar(char rune, wrapLen int, lineLen *int, inEscSeq bool, lastSeenEscSeq string, out *strings.Builder) {
 	// handle reaching the end of the line as dictated by wrapLen or by finding
 	// a newline character
-	if (*lineLen == wrapLen && !inEscSeq && char != '\n') || (char == '\n') {
+	if (*lineLen >= wrapLen && !inEscSeq && char != '\n') || (char == '\n') {
 		if lastSeenEscSeq != "" {
 			// terminate escape sequence and the line; and restart the escape
 			// sequence in the next line

--- a/text/wrap_test.go
+++ b/text/wrap_test.go
@@ -68,6 +68,9 @@ func TestWrapHard(t *testing.T) {
 	assert.Equal(t, expectedUnBold, WrapHard(textUnBold, 23))
 	assert.Equal(t, expectedWide, WrapHard(textWide, 10))
 	assert.Equal(t, expectedWideColored, WrapHard(textWideColored, 10))
+	// wide runes (width 2) must still wrap when wrapLen is odd: the line length
+	// steps over wrapLen instead of landing on it exactly.
+	assert.Equal(t, "世世\n世世\n世世", WrapHard("世世世世世世", 3))
 }
 
 func TestFoo(t *testing.T) {


### PR DESCRIPTION
`text.WrapHard` doesn't wrap text made of wide runes when `wrapLen` is odd.

`appendChar` terminates a line with an exact equality check:

```go
if (*lineLen == wrapLen && !inEscSeq && char != '\n') || (char == '\n') {
```

`lineLen` is advanced by `RuneWidth(char)`, which is `2` for wide (CJK/fullwidth) runes. With an odd `wrapLen`, `lineLen` steps from `wrapLen-1` to `wrapLen+1`, so it never equals `wrapLen` and the wrap never fires. For example `WrapHard("世世世世世世", 3)` returns the whole string on one line instead of wrapping.

Changing the comparison to `>=` makes the line wrap as soon as its width reaches `wrapLen`. ASCII (width 1) is unaffected, since `lineLen` still lands on `wrapLen` exactly, and the existing even-`wrapLen` wide-character tests are unchanged.

Added a `WrapHard("世世世世世世", 3)` case to `TestWrapHard` (fails before, passes after). `go test ./text/...` is green.
