### PR TITLE
text: trim to display width so CJK content respects maxLen

### DIFF
--- a/text/string.go
+++ b/text/string.go
@@ -286,13 +286,16 @@ func StringWidthWithoutEscSequences(str string) int {
 	return count
 }
 
-// Trim trims a string to the given length while ignoring escape sequences. For
-// ex.:
+// Trim trims a string to the given display width (maxLen columns) while
+// ignoring escape sequences. Wide East Asian characters count as two columns,
+// so the result never exceeds maxLen columns. For ex.:
 //
 //	Trim("Ghost", 3) == "Gho"
 //	Trim("Ghost", 6) == "Ghost"
 //	Trim("\x1b[33mGhost\x1b[0m", 3) == "\x1b[33mGho\x1b[0m"
 //	Trim("\x1b[33mGhost\x1b[0m", 6) == "\x1b[33mGhost\x1b[0m"
+//	Trim("生命生命", 3) == "生"
+//	Trim("生命生命", 4) == "生命"
 func Trim(str string, maxLen int) string {
 	if maxLen <= 0 {
 		return ""
@@ -301,7 +304,7 @@ func Trim(str string, maxLen int) string {
 	var out strings.Builder
 	out.Grow(maxLen)
 
-	outLen, esp := 0, EscSeqParser{}
+	outLen, full, esp := 0, false, EscSeqParser{}
 	for _, sChr := range str {
 		if esp.InSequence() {
 			esp.Consume(sChr)
@@ -313,10 +316,17 @@ func Trim(str string, maxLen int) string {
 			out.WriteRune(sChr)
 			continue
 		}
-		if outLen < maxLen {
-			outLen++
-			out.WriteRune(sChr)
-			continue
+		// Count the display width of the rune (wide East Asian characters
+		// occupy two columns) instead of counting runes, so the result never
+		// exceeds maxLen columns. Once a rune no longer fits, stop emitting
+		// visible runes but keep copying any trailing escape sequences.
+		if !full {
+			if w := RuneWidth(sChr); outLen+w <= maxLen {
+				outLen += w
+				out.WriteRune(sChr)
+				continue
+			}
+			full = true
 		}
 	}
 	return out.String()

--- a/text/string_test.go
+++ b/text/string_test.go
@@ -294,6 +294,9 @@ func TestSnip(t *testing.T) {
 	assert.Equal(t, "\x1b]8;;http://example.com\x1b\\Ghost\x1b]8;;\x1b\\", Snip("\x1b]8;;http://example.com\x1b\\Ghost\x1b]8;;\x1b\\", 7, "~"))
 	assert.Equal(t, "\x1b]8;;http://example.com\x1b\\Gh\x1b]8;;\x1b\\~", Snip("\x1b]8;;http://example.com\x1b\\Ghost\x1b]8;;\x1b\\", 3, "~"))
 	assert.Equal(t, "\x1b[33m\x1b]8;;http://example.com\x1b\\Gh\x1b]8;;\x1b\\\x1b[0m~", Snip("\x1b[33m\x1b]8;;http://example.com\x1b\\Ghost\x1b]8;;\x1b\\\x1b[0m", 3, "~"))
+	// wide East Asian characters count as two columns
+	assert.Equal(t, "生命~", Snip("生命生命生命", 5, "~"))
+	assert.Equal(t, "生命生命", Snip("生命生命", 8, "~"))
 }
 
 func ExampleStringWidth() {
@@ -361,6 +364,12 @@ func TestTrim(t *testing.T) {
 	assert.Equal(t, "\x1b[33mGho\x1b[0m", Trim("\x1b[33mGhost\x1b[0m", 3))
 	assert.Equal(t, "\x1b[33mGhost\x1b[0m", Trim("\x1b[33mGhost\x1b[0m", 6))
 	assert.Equal(t, "\x1b]8;;http://example.com\x1b\\Gho\x1b]8;;\x1b\\", Trim("\x1b]8;;http://example.com\x1b\\Ghost\x1b]8;;\x1b\\", 3))
+	// wide East Asian characters count as two columns
+	assert.Equal(t, "生", Trim("生命生命", 3))
+	assert.Equal(t, "生命", Trim("生命生命", 4))
+	assert.Equal(t, "aツ", Trim("aツb", 3))
+	assert.Equal(t, "", Trim("ツ", 1))
+	assert.Equal(t, "\x1b[33m生命\x1b[0m", Trim("\x1b[33m生命生命\x1b[0m", 4))
 }
 
 func ExampleWiden() {


### PR DESCRIPTION
## Proposed Changes
  - `text.Trim` counted runes rather than display width, so it kept `maxLen` runes no matter how wide they are.
  - Its callers all pass a display-width budget: `text.Snip` derives its threshold and indicator size from `StringWidthWithoutEscSequences`, `table` only trims a rendered line after `StringWidthWithoutEscSequences(line) > Style().Size.WidthMax`, and the `progress` renderer trims a line to the terminal width. With wide East Asian text those callers overflowed, because a 2-column character was charged as 1 column.
  - `Trim` now adds `RuneWidth` per rune and stops once a rune no longer fits, while still copying any trailing escape sequences so colors are still closed. Added wide-character cases to `TestTrim` and `TestSnip`.

Before:

    text.Trim("生命生命", 4)         => "生命生命"   (display width 8, budget 4)
    text.Snip("生命生命生命", 5, "~") => "生命生命~"  (display width 9, budget 5)

After:

    text.Trim("生命生命", 4)         => "生命"      (width 4)
    text.Snip("生命生命生命", 5, "~") => "生命~"     (width 5)

ASCII output is unchanged, since rune count equals display width there. The `text`, `table`, and `list` suites pass. The only failure I saw was the timing-sensitive `progress.TestProgress_RenderNeverStarted`, which flakes intermittently on `main` without this change as well.
