### PR TITLE
table: stack vertically-merged rows into wrapped cell height; fixes #261

### DIFF
--- a/table/render.go
+++ b/table/render.go
@@ -270,7 +270,7 @@ func (t *Table) renderRow(out *strings.Builder, row rowStr, hint renderHint) {
 		// fit every column into the allowedColumnLength/maxColumnLength limit
 		// and in the process find the max. number of lines in any column in
 		// this row
-		colMaxLines, rowWrapped := t.wrapRow(row)
+		colMaxLines, rowWrapped := t.wrapRow(row, hint)
 
 		// if there is just 1 line in all columns, add the row as such; else
 		// split each column into individual lines and render them one-by-one
@@ -313,9 +313,22 @@ func (t *Table) renderRowSeparator(out *strings.Builder, hint renderHint) {
 }
 
 func (t *Table) renderRows(out *strings.Builder, rows []rowStr, hint renderHint) {
-	for rowIdx, row := range rows {
+	interleaveVerticalMerge := t.shouldInterleaveVerticalMerge(hint)
+	for rowIdx := 0; rowIdx < len(rows); rowIdx++ {
+		row := rows[rowIdx]
+
+		// stack rows that are being vertically merged into one shared block so
+		// the differing columns fill the merged cell's wrapped height instead
+		// of leaving blank lines below it (issue #261)
+		groupEnd := rowIdx + 1
+		if interleaveVerticalMerge {
+			if groupEnd = t.verticalMergeGroupEnd(rows, rowIdx); groupEnd > rowIdx+1 {
+				row = t.combineVerticalMergeGroup(rows, rowIdx, groupEnd)
+			}
+		}
+
 		hint.isFirstRow = rowIdx == 0
-		hint.isLastRow = rowIdx == len(rows)-1
+		hint.isLastRow = groupEnd == len(rows)
 		hint.rowNumber = rowIdx + 1
 		t.renderRow(out, row, hint)
 
@@ -332,6 +345,9 @@ func (t *Table) renderRows(out *strings.Builder, rows []rowStr, hint renderHint)
 			}
 			t.renderRowSeparator(out, hintSep)
 		}
+
+		// skip the rows that were stacked into the block rendered above
+		rowIdx = groupEnd - 1
 	}
 }
 

--- a/table/render_automerge_wrap_test.go
+++ b/table/render_automerge_wrap_test.go
@@ -1,0 +1,287 @@
+package table
+
+import (
+	"testing"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+// TestTable_Render_AutoMerge_Wrap covers issue #261: when a vertically merged
+// (ColumnConfig.AutoMerge) column is wrapped by WidthMax, the rows merged into
+// it should stack their differing columns into the merged cell's wrapped height
+// instead of leaving blank lines below it.
+func TestTable_Render_AutoMerge_Wrap(t *testing.T) {
+	newMergedTable := func(widthMax int) Writer {
+		tw := NewWriter()
+		tw.SetColumnConfigs([]ColumnConfig{
+			{Name: "C1", AutoMerge: true, WidthMax: widthMax, WidthMaxEnforcer: text.WrapSoft},
+			{Name: "C2"},
+		})
+		tw.AppendHeader(Row{"C1", "C2"})
+		return tw
+	}
+
+	t.Run("issue 261 example", func(t *testing.T) {
+		tw := newMergedTable(10)
+		tw.AppendRow(Row{"very long row value that wraps", "x"})
+		tw.AppendRow(Row{"very long row value that wraps", "y"})
+
+		compareOutput(t, tw.Render(), `
++------------+----+
+| C1         | C2 |
++------------+----+
+| very long  | x  |
+| row value  | y  |
+| that wraps |    |
++------------+----+`)
+	})
+
+	t.Run("group fully fills wrapped height", func(t *testing.T) {
+		tw := newMergedTable(12)
+		tw.AppendRow(Row{"very long row value that wraps", "x"})
+		tw.AppendRow(Row{"very long row value that wraps", "y"})
+		tw.AppendRow(Row{"very long row value that wraps", "z"})
+
+		compareOutput(t, tw.Render(), `
++--------------+----+
+| C1           | C2 |
++--------------+----+
+| very long    | x  |
+| row value    | y  |
+| that wraps   | z  |
++--------------+----+`)
+	})
+
+	t.Run("more members than wrapped lines", func(t *testing.T) {
+		tw := newMergedTable(10)
+		tw.AppendRow(Row{"very long row value that wraps", "a"})
+		tw.AppendRow(Row{"very long row value that wraps", "b"})
+		tw.AppendRow(Row{"very long row value that wraps", "c"})
+		tw.AppendRow(Row{"very long row value that wraps", "d"})
+
+		compareOutput(t, tw.Render(), `
++------------+----+
+| C1         | C2 |
++------------+----+
+| very long  | a  |
+| row value  | b  |
+| that wraps | c  |
+|            | d  |
++------------+----+`)
+	})
+
+	t.Run("three columns", func(t *testing.T) {
+		tw := NewWriter()
+		tw.SetColumnConfigs([]ColumnConfig{
+			{Name: "C1", AutoMerge: true, WidthMax: 10, WidthMaxEnforcer: text.WrapSoft},
+			{Name: "C2"},
+			{Name: "C3"},
+		})
+		tw.AppendHeader(Row{"C1", "C2", "C3"})
+		tw.AppendRow(Row{"very long row value that wraps", "x", "A"})
+		tw.AppendRow(Row{"very long row value that wraps", "y", "B"})
+
+		compareOutput(t, tw.Render(), `
++------------+----+----+
+| C1         | C2 | C3 |
++------------+----+----+
+| very long  | x  | A  |
+| row value  | y  | B  |
+| that wraps |    |    |
++------------+----+----+`)
+	})
+
+	t.Run("different values start a new group", func(t *testing.T) {
+		tw := newMergedTable(10)
+		tw.AppendRow(Row{"very long row value that wraps", "x"})
+		tw.AppendRow(Row{"very long row value that wraps", "y"})
+		tw.AppendRow(Row{"different value that also wraps", "z"})
+
+		compareOutput(t, tw.Render(), `
++------------+----+
+| C1         | C2 |
++------------+----+
+| very long  | x  |
+| row value  | y  |
+| that wraps |    |
+| different  | z  |
+| value that |    |
+| also wraps |    |
++------------+----+`)
+	})
+
+	t.Run("two merged columns with different boundaries", func(t *testing.T) {
+		tw := NewWriter()
+		tw.SetColumnConfigs([]ColumnConfig{
+			{Name: "C1", AutoMerge: true, WidthMax: 8, WidthMaxEnforcer: text.WrapSoft},
+			{Name: "C2", AutoMerge: true},
+			{Name: "C3"},
+		})
+		tw.AppendHeader(Row{"C1", "C2", "C3"})
+		tw.AppendRow(Row{"alpha beta gamma", "K1", "v1"})
+		tw.AppendRow(Row{"alpha beta gamma", "K1", "v2"})
+		tw.AppendRow(Row{"alpha beta gamma", "K2", "v3"})
+
+		// C1 spans all three rows, so the block is its wrapped height; C2 does
+		// its own vertical merge within that block (K1 over the first two rows,
+		// K2 on the third).
+		compareOutput(t, tw.Render(), `
++----------+----+----+
+| C1       | C2 | C3 |
++----------+----+----+
+| alpha    | K1 | v1 |
+| beta     |    | v2 |
+| gamma    | K2 | v3 |
++----------+----+----+`)
+	})
+
+	t.Run("inner merged column re-merges within the block", func(t *testing.T) {
+		tw := NewWriter()
+		tw.SetColumnConfigs([]ColumnConfig{
+			{Name: "C1", AutoMerge: true, WidthMax: 8, WidthMaxEnforcer: text.WrapSoft},
+			{Name: "C2", AutoMerge: true},
+			{Name: "C3"},
+		})
+		tw.AppendHeader(Row{"C1", "C2", "C3"})
+		tw.AppendRow(Row{"alpha beta gamma", "K1", "v1"})
+		tw.AppendRow(Row{"alpha beta gamma", "K2", "v2"})
+		tw.AppendRow(Row{"alpha beta gamma", "K2", "v3"})
+
+		compareOutput(t, tw.Render(), `
++----------+----+----+
+| C1       | C2 | C3 |
++----------+----+----+
+| alpha    | K1 | v1 |
+| beta     | K2 | v2 |
+| gamma    |    | v3 |
++----------+----+----+`)
+	})
+
+	t.Run("merged cell that wraps then changes is not stacked", func(t *testing.T) {
+		tw := NewWriter()
+		tw.SetColumnConfigs([]ColumnConfig{
+			{Name: "C1", AutoMerge: true, WidthMax: 4, WidthMaxEnforcer: text.WrapSoft},
+			{Name: "C2"},
+		})
+		tw.AppendHeader(Row{"C1", "C2"})
+		tw.AppendRow(Row{"aa bb", "x"})
+		tw.AppendRow(Row{"z", "y"})
+
+		// "aa bb" wraps to two lines, so the next row cannot slot into it
+		// without misaligning; each row keeps its own line.
+		compareOutput(t, tw.Render(), `
++------+----+
+| C1   | C2 |
++------+----+
+| aa   | x  |
+| bb   |    |
+| z    | y  |
++------+----+`)
+	})
+
+	t.Run("short values are unaffected", func(t *testing.T) {
+		tw := newMergedTable(10)
+		tw.AppendRow(Row{"short", "x"})
+		tw.AppendRow(Row{"short", "y"})
+		tw.AppendRow(Row{"short", "z"})
+
+		compareOutput(t, tw.Render(), `
++-------+----+
+| C1    | C2 |
++-------+----+
+| short | x  |
+|       | y  |
+|       | z  |
++-------+----+`)
+	})
+
+	t.Run("fallback when a non-merged column also wraps", func(t *testing.T) {
+		tw := NewWriter()
+		tw.SetColumnConfigs([]ColumnConfig{
+			{Name: "C1", AutoMerge: true, WidthMax: 10, WidthMaxEnforcer: text.WrapSoft},
+			{Name: "C2", WidthMax: 8, WidthMaxEnforcer: text.WrapSoft},
+		})
+		tw.AppendHeader(Row{"C1", "C2"})
+		tw.AppendRow(Row{"very long row value that wraps", "short value"})
+		tw.AppendRow(Row{"very long row value that wraps", "another short value"})
+
+		// the second column wraps too, so the rows cannot be stacked without
+		// misaligning columns; fall back to trimming the trailing blank lines.
+		compareOutput(t, tw.Render(), `
++------------+----------+
+| C1         | C2       |
++------------+----------+
+| very long  | short    |
+| row value  | value    |
+| that wraps |          |
+|            | another  |
+|            | short    |
+|            | value    |
++------------+----------+`)
+	})
+
+	t.Run("differing row config breaks the group", func(t *testing.T) {
+		tw := newMergedTable(10)
+		tw.AppendRow(Row{"very long row value that wraps", "x"})
+		tw.AppendRow(Row{"very long row value that wraps", "y"}, RowConfig{AutoMerge: true})
+
+		// the second row carries a different row config, so it is not stacked
+		// into the first; only the trailing blank lines are trimmed.
+		compareOutput(t, tw.Render(), `
++------------+----+
+| C1         | C2 |
++------------+----+
+| very long  | x  |
+| row value  |    |
+| that wraps |    |
+|            | y  |
++------------+----+`)
+	})
+
+	t.Run("later non-stackable row breaks the group partway", func(t *testing.T) {
+		tw := NewWriter()
+		tw.SetColumnConfigs([]ColumnConfig{
+			{Name: "C1", AutoMerge: true, WidthMax: 10, WidthMaxEnforcer: text.WrapSoft},
+			{Name: "C2", WidthMax: 8, WidthMaxEnforcer: text.WrapSoft},
+		})
+		tw.AppendHeader(Row{"C1", "C2"})
+		tw.AppendRow(Row{"very long row value that wraps", "x"})
+		tw.AppendRow(Row{"very long row value that wraps", "y"})
+		tw.AppendRow(Row{"very long row value that wraps", "multi word value"})
+
+		// the first two rows stack; the third wraps in C2 and cannot join, so
+		// it renders on its own below the merged block.
+		compareOutput(t, tw.Render(), `
++------------+----------+
+| C1         | C2       |
++------------+----------+
+| very long  | x        |
+| row value  | y        |
+| that wraps |          |
+|            | multi    |
+|            | word     |
+|            | value    |
++------------+----------+`)
+	})
+
+	t.Run("gated off when rows are separated", func(t *testing.T) {
+		tw := newMergedTable(10)
+		tw.SetStyle(StyleLight)
+		tw.Style().Options.SeparateRows = true
+		tw.AppendRow(Row{"very long row value that wraps", "x"})
+		tw.AppendRow(Row{"very long row value that wraps", "y"})
+
+		// with separators the rows stay visually distinct; only the trailing
+		// blank lines are trimmed.
+		compareOutput(t, tw.Render(), `
+┌────────────┬────┐
+│ C1         │ C2 │
+├────────────┼────┤
+│ very long  │ x  │
+│ row value  │    │
+│ that wraps │    │
+│            ├────┤
+│            │ y  │
+└────────────┴────┘`)
+	})
+}

--- a/table/table.go
+++ b/table/table.go
@@ -947,20 +947,187 @@ func (t *Table) shouldSeparateRows(rowIdx int, numRows int) bool {
 	return true
 }
 
-func (t *Table) wrapRow(row rowStr) (int, rowStr) {
+// wrapCell fits a single column's value into its width limit (WidthMax, or the
+// column's longest line when no limit is set) using the column's enforcer.
+func (t *Table) wrapCell(colIdx int, colStr string) string {
+	widthEnforcer := t.columnConfigMap[colIdx].getWidthMaxEnforcer()
+	maxWidth := t.getColumnWidthMax(colIdx)
+	if maxWidth == 0 {
+		maxWidth = t.maxColumnLengths[colIdx]
+	}
+	return widthEnforcer(colStr, maxWidth)
+}
+
+func (t *Table) wrapRow(row rowStr, hint renderHint) (int, rowStr) {
 	colMaxLines := 0
 	rowWrapped := make(rowStr, len(row))
 	for colIdx, colStr := range row {
-		widthEnforcer := t.columnConfigMap[colIdx].getWidthMaxEnforcer()
-		maxWidth := t.getColumnWidthMax(colIdx)
-		if maxWidth == 0 {
-			maxWidth = t.maxColumnLengths[colIdx]
+		rowWrapped[colIdx] = t.wrapCell(colIdx, colStr)
+		// a cell that is being merged into the one above renders empty in this
+		// row, so its (possibly wrapped) height must not stretch the row and
+		// leave blank lines trailing the merged content; see issue #261
+		if t.shouldMergeCellsVerticallyAbove(colIdx, hint) {
+			continue
 		}
-		rowWrapped[colIdx] = widthEnforcer(colStr, maxWidth)
 		colNumLines := strings.Count(rowWrapped[colIdx], "\n") + 1
 		if colNumLines > colMaxLines {
 			colMaxLines = colNumLines
 		}
 	}
+	if colMaxLines == 0 {
+		// every column merged into the row above; keep one (blank) line so the
+		// row still occupies its place
+		colMaxLines = 1
+	}
 	return colMaxLines, rowWrapped
+}
+
+// shouldInterleaveVerticalMerge reports whether consecutive body rows that are
+// being vertically merged (ColumnConfig.AutoMerge) may be rendered as a single
+// shared block. Doing so lets the differing columns stack into the merged
+// cell's wrapped height instead of leaving blank lines below it (issue #261).
+//
+// It is intentionally restricted to the plain, unambiguous case - no row
+// separators, auto-index, or per-row coloring - so it never alters any other
+// layout and falls back to the regular row-by-row rendering everywhere else.
+func (t *Table) shouldInterleaveVerticalMerge(hint renderHint) bool {
+	if hint.isHeaderRow || hint.isFooterRow {
+		return false
+	}
+	if t.style.Options.SeparateRows || len(t.separators) > 0 {
+		return false
+	}
+	if t.autoIndex || t.pager.size > 0 {
+		return false
+	}
+	if t.rowPainter != nil || t.rowPainterWithAttributes != nil || t.style.Color.RowAlternate != nil {
+		return false
+	}
+	for colIdx := 0; colIdx < t.numColumns; colIdx++ {
+		if t.columnConfigMap[colIdx].AutoMerge {
+			return true
+		}
+	}
+	return false
+}
+
+// verticalMergeGroupEnd returns the exclusive end index of the maximal run of
+// rows starting at "start" that can be stacked into a single block: rows that
+// carry the same config and each add just one line, so they slot into the
+// wrapped height of the merged cell(s) spanning them.
+func (t *Table) verticalMergeGroupEnd(rows []rowStr, start int) int {
+	if !t.rowVerticallyStackable(rows[start]) {
+		return start + 1
+	}
+	end := start + 1
+	for end < len(rows) {
+		if t.rowsConfigMap[start] != t.rowsConfigMap[end] {
+			break
+		}
+		if !t.rowStacksBelow(rows[end-1], rows[end]) {
+			break
+		}
+		end++
+	}
+	return end
+}
+
+// rowVerticallyStackable reports whether a row's non-merged cells each render on
+// a single line, so it occupies a single line when stacked (a merged cell may
+// still wrap - it provides the vertical space the stacked rows slot into).
+func (t *Table) rowVerticallyStackable(row rowStr) bool {
+	for colIdx := 0; colIdx < t.numColumns && colIdx < len(row); colIdx++ {
+		if t.columnConfigMap[colIdx].AutoMerge {
+			continue
+		}
+		if t.cellWraps(colIdx, row[colIdx]) {
+			return false
+		}
+	}
+	return true
+}
+
+// rowStacksBelow reports whether "cur" can be stacked right below "prev" within
+// a shared merge block, i.e. it adds exactly one line. A merged column that
+// keeps its value simply continues the cell above; any column that changes must
+// fit on a single line (and a merged column that changes must also have left
+// its previous value on a single line, else its wrapped height would not line
+// up with the stacked rows).
+func (t *Table) rowStacksBelow(prev, cur rowStr) bool {
+	for colIdx := 0; colIdx < t.numColumns; colIdx++ {
+		prevVal, curVal := "", ""
+		if colIdx < len(prev) {
+			prevVal = prev[colIdx]
+		}
+		if colIdx < len(cur) {
+			curVal = cur[colIdx]
+		}
+		merged := t.columnConfigMap[colIdx].AutoMerge
+		if merged && curVal == prevVal {
+			continue
+		}
+		if t.cellWraps(colIdx, curVal) {
+			return false
+		}
+		if merged && t.cellWraps(colIdx, prevVal) {
+			return false
+		}
+	}
+	return true
+}
+
+// cellWraps reports whether a column's value renders on more than one line.
+func (t *Table) cellWraps(colIdx int, colStr string) bool {
+	return strings.Contains(t.wrapCell(colIdx, colStr), "\n")
+}
+
+// combineVerticalMergeGroup collapses rows[start:end] into a single row. A
+// merged column that never changes keeps its single (spanning) value; every
+// other column stacks the rows' values one below the other, blanking a merged
+// value that repeats so it still reads as one vertically merged cell.
+func (t *Table) combineVerticalMergeGroup(rows []rowStr, start, end int) rowStr {
+	combined := make(rowStr, t.numColumns)
+	for colIdx := 0; colIdx < t.numColumns; colIdx++ {
+		if t.columnConfigMap[colIdx].AutoMerge && t.mergedColumnIsConstant(rows, start, end, colIdx) {
+			if colIdx < len(rows[start]) {
+				combined[colIdx] = rows[start][colIdx]
+			}
+			continue
+		}
+		lines := make([]string, 0, end-start)
+		prevCell := ""
+		for rowIdx := start; rowIdx < end; rowIdx++ {
+			cell := ""
+			if colIdx < len(rows[rowIdx]) {
+				cell = rows[rowIdx][colIdx]
+			}
+			line := cell
+			if t.columnConfigMap[colIdx].AutoMerge && rowIdx > start && cell == prevCell {
+				line = ""
+			}
+			prevCell = cell
+			lines = append(lines, line)
+		}
+		combined[colIdx] = strings.Join(lines, "\n")
+	}
+	return combined
+}
+
+// mergedColumnIsConstant reports whether a merged column holds the same value
+// across every row in rows[start:end].
+func (t *Table) mergedColumnIsConstant(rows []rowStr, start, end, colIdx int) bool {
+	first := ""
+	if colIdx < len(rows[start]) {
+		first = rows[start][colIdx]
+	}
+	for rowIdx := start + 1; rowIdx < end; rowIdx++ {
+		val := ""
+		if colIdx < len(rows[rowIdx]) {
+			val = rows[rowIdx][colIdx]
+		}
+		if val != first {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
When a column has both AutoMerge and WidthMax, a merged cell rendered blank but still forced the row to the pre-merge wrapped height, leaving trailing blank lines below the merged content.

Body rows spanned by the same merged cell are now rendered as one shared block so the differing columns slot into the merged cell's wrapped height instead of leaving blanks below it. The block is the full span of a merged cell, and any inner merged column does its own vertical merge within it. This is gated to the plain case (no row separators, auto-index, pager, or per-row coloring) and only kicks in when the stacked rows each fit on a single line, so it never changes any other layout; everything else falls back to trimming the trailing blank lines.